### PR TITLE
ci: Update trigger branch in deploy.yml to ckm-v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI-Validate Deployment
 on:
   push:
     branches:
-      - main
+      - ckm-v2
   schedule:
     - cron: '0 6,18 * * *'  # Runs at 6:00 AM and 6:00 PM GMT
     


### PR DESCRIPTION
## Purpose
Changed the trigger branch name in deploy.yml from main to ckm-v2.
* This pull request includes a change to the deployment workflow configuration in the `.github/workflows/deploy.yml` file. The change updates the branch name for the deployment validation.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L5-R5): Changed the branch for the `push` event from `main` to `ckm-v2`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No



## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
