### PR TITLE
fix: Use aifoundry storage account for functionapps

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -658,3 +658,4 @@ output aiSearchId string = aiSearch.id
 output aiSearchTarget string = 'https://${aiSearch.name}.search.windows.net'
 output aiSearchService string = aiSearch.name
 output aiProjectName string = aiHubProject.name
+output storageAccountName string = storageNameCleaned

--- a/infra/deploy_app_service.bicep
+++ b/infra/deploy_app_service.bicep
@@ -155,6 +155,8 @@ resource Website 'Microsoft.Web/sites@2020-06-01' = {
   properties: {
     serverFarmId: HostingPlanName
     siteConfig: {
+      alwaysOn: true
+      ftpsState: 'Disabled'
       appSettings: [
         {
           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -223,6 +225,18 @@ resource Website 'Microsoft.Web/sites@2020-06-01' = {
         }
       ]
       linuxFxVersion: WebAppImageName
+    }
+  }
+  resource basicPublishingCredentialsPoliciesFtp 'basicPublishingCredentialsPolicies' = {
+    name: 'ftp'
+    properties: {
+      allow: false
+    }
+  }
+  resource basicPublishingCredentialsPoliciesScm 'basicPublishingCredentialsPolicies' = {
+    name: 'scm'
+    properties: {
+      allow: false
     }
   }
   dependsOn: [HostingPlan]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -192,6 +192,7 @@ module azureFunctionsCharts 'deploy_azure_function_charts.bicep' = {
     sqlDbUser: sqlDBModule.outputs.sqlDbUser
     sqlDbPwd:keyVault.getSecret('SQLDB-PASSWORD')
     // managedIdentityObjectId:managedIdentityModule.outputs.managedIdentityOutput.objectId
+    storageAccountName:aifoundry.outputs.storageAccountName
   }
   dependsOn:[keyVault]
 }
@@ -217,6 +218,7 @@ module azureragFunctionsRag 'deploy_azure_function_rag.bicep' = {
     sqlDbPwd:keyVault.getSecret('SQLDB-PASSWORD')
     aiProjectName:aifoundry.outputs.aiProjectName
     // managedIdentityObjectId:managedIdentityModule.outputs.managedIdentityOutput.objectId
+    storageAccountName:aifoundry.outputs.storageAccountName
   }
   dependsOn:[keyVault]
 }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10535791601593705798"
+      "templateHash": "15021662036060306033"
     }
   },
   "parameters": {
@@ -366,7 +366,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "7803735516770365352"
+              "templateHash": "6605413385617905631"
             }
           },
           "parameters": {
@@ -1018,6 +1018,10 @@
             "aiProjectName": {
               "type": "string",
               "value": "[variables('aiProjectName')]"
+            },
+            "storageAccountName": {
+              "type": "string",
+              "value": "[variables('storageNameCleaned')]"
             }
           }
         }
@@ -1792,6 +1796,9 @@
               },
               "secretName": "SQLDB-PASSWORD"
             }
+          },
+          "storageAccountName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.storageAccountName.value]"
           }
         },
         "template": {
@@ -1801,7 +1808,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "7630355864427423039"
+              "templateHash": "4998991713682676077"
             }
           },
           "parameters": {
@@ -1828,29 +1835,17 @@
             },
             "imageTag": {
               "type": "string"
+            },
+            "storageAccountName": {
+              "type": "string"
             }
           },
           "variables": {
             "functionAppName": "[format('{0}-charts-fn', parameters('solutionName'))]",
-            "storageaccountname": "[format('{0}chartfnacc', parameters('solutionName'))]",
             "dockerImage": "[format('DOCKER|kmcontainerreg.azurecr.io/km-charts-function:{0}', parameters('imageTag'))]",
             "environmentName": "[format('{0}-charts-fn-env', parameters('solutionName'))]"
           },
           "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "apiVersion": "2023-05-01",
-              "name": "[variables('storageaccountname')]",
-              "location": "[resourceGroup().location]",
-              "sku": {
-                "name": "Standard_LRS"
-              },
-              "kind": "StorageV2",
-              "properties": {
-                "accessTier": "Hot",
-                "allowSharedKeyAccess": false
-              }
-            },
             {
               "type": "Microsoft.App/managedEnvironments",
               "apiVersion": "2024-03-01",
@@ -1892,8 +1887,8 @@
                 "siteConfig": {
                   "appSettings": [
                     {
-                      "name": "AzureWebJobsStorage",
-                      "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix=core.windows.net', reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageaccountname')), '2023-05-01', 'full'))]"
+                      "name": "AzureWebJobsStorage__accountname",
+                      "value": "[parameters('storageAccountName')]"
                     },
                     {
                       "name": "SQLDB_DATABASE",
@@ -1925,22 +1920,7 @@
                 "storageAccountRequired": false
               },
               "dependsOn": [
-                "[resourceId('Microsoft.App/managedEnvironments', variables('environmentName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageaccountname'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.Storage/storageAccounts/{0}', variables('storageaccountname'))]",
-              "name": "[guid(subscription().id, resourceGroup().id, resourceId('Microsoft.Web/sites', variables('functionAppName')), 'StorageBlobDataContributor')]",
-              "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
-                "principalId": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2023-12-01', 'full').identity.principalId]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageaccountname'))]"
+                "[resourceId('Microsoft.App/managedEnvironments', variables('environmentName'))]"
               ]
             }
           ]
@@ -2028,6 +2008,9 @@
           },
           "aiProjectName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiProjectName.value]"
+          },
+          "storageAccountName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.storageAccountName.value]"
           }
         },
         "template": {
@@ -2037,7 +2020,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "17601259288614778920"
+              "templateHash": "11421360177429904471"
             }
           },
           "parameters": {
@@ -2091,29 +2074,17 @@
             },
             "imageTag": {
               "type": "string"
+            },
+            "storageAccountName": {
+              "type": "string"
             }
           },
           "variables": {
             "functionAppName": "[format('{0}-rag-fn', parameters('solutionName'))]",
-            "storageaccountname": "[format('{0}ragfnacc', parameters('solutionName'))]",
             "dockerImage": "[format('DOCKER|kmcontainerreg.azurecr.io/km-rag-function:{0}', parameters('imageTag'))]",
             "environmentName": "[format('{0}-rag-fn-env', parameters('solutionName'))]"
           },
           "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "apiVersion": "2023-05-01",
-              "name": "[variables('storageaccountname')]",
-              "location": "[resourceGroup().location]",
-              "sku": {
-                "name": "Standard_LRS"
-              },
-              "kind": "StorageV2",
-              "properties": {
-                "accessTier": "Hot",
-                "allowSharedKeyAccess": false
-              }
-            },
             {
               "type": "Microsoft.App/managedEnvironments",
               "apiVersion": "2024-03-01",
@@ -2155,8 +2126,8 @@
                 "siteConfig": {
                   "appSettings": [
                     {
-                      "name": "AzureWebJobsStorage",
-                      "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix=core.windows.net', reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageaccountname')), '2023-05-01', 'full'))]"
+                      "name": "AzureWebJobsStorage__accountname",
+                      "value": "[parameters('storageAccountName')]"
                     },
                     {
                       "name": "PYTHON_ENABLE_INIT_INDEXING",
@@ -2228,22 +2199,7 @@
                 "storageAccountRequired": false
               },
               "dependsOn": [
-                "[resourceId('Microsoft.App/managedEnvironments', variables('environmentName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageaccountname'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.Storage/storageAccounts/{0}', variables('storageaccountname'))]",
-              "name": "[guid(subscription().id, resourceGroup().id, resourceId('Microsoft.Web/sites', variables('functionAppName')), 'StorageBlobDataContributor')]",
-              "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
-                "principalId": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2023-12-01', 'full').identity.principalId]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageaccountname'))]"
+                "[resourceId('Microsoft.App/managedEnvironments', variables('environmentName'))]"
               ]
             },
             {
@@ -2400,7 +2356,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "2717758861842552802"
+              "templateHash": "2254598285697484618"
             }
           },
           "parameters": {
@@ -2543,6 +2499,28 @@
           },
           "resources": [
             {
+              "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', parameters('WebsiteName'), 'ftp')]",
+              "properties": {
+                "allow": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('WebsiteName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', parameters('WebsiteName'), 'scm')]",
+              "properties": {
+                "allow": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('WebsiteName'))]"
+              ]
+            },
+            {
               "type": "Microsoft.Web/serverfarms",
               "apiVersion": "2020-06-01",
               "name": "[parameters('HostingPlanName')]",
@@ -2567,6 +2545,8 @@
               "properties": {
                 "serverFarmId": "[parameters('HostingPlanName')]",
                 "siteConfig": {
+                  "alwaysOn": true,
+                  "ftpsState": "Disabled",
                   "appSettings": [
                     {
                       "name": "APPINSIGHTS_INSTRUMENTATIONKEY",


### PR DESCRIPTION
## Purpose

This pull request includes several changes to the infrastructure deployment scripts, mainly focusing on the management of storage account names and enhancing the configuration of Azure resources. The most important changes include adding new output parameters, updating resource configurations, and removing redundant storage account definitions.
[Bug 14635](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/14635): [BugBash] - Feedback - KM Generic- App Service to have Always On
[Bug 14639](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/14639): [BugBash] - Feedback - KM Generic- Need two storage accounts instead of four storage accounts

### Key Changes:

#### Storage Account Management:
* Added `storageAccountName` as an output parameter in `infra/deploy_ai_foundry.bicep` and passed it to other modules 

#### Resource Configuration:
* Enabled `alwaysOn` and disabled `ftpsState` for the `Website` resource in `infra/deploy_app_service.bicep` 

#### Removal of Redundant Definitions:
* Removed storage account resource definitions and role assignments from `infra/deploy_azure_function_charts.bicep`, `infra/deploy_azure_function_rag.bicep`, and `infra/main.json`

#### Configuration Updates:
* Updated app settings to use `storageAccountName` instead of hardcoded values in `infra/deploy_azure_function_charts.bicep`, `infra/deploy_azure_function_rag.bicep`, and `infra/main.json` 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ X] No

## Golden Path Validation
- [x ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

