### PR TITLE
fix: Automatic pulling latest code from repo, Policy violation for CosmosDB and ACR, env name max 20 characters limit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,9 @@
             ]
         }
     },
-    "postCreateCommand": "python3 -m pip install -r infra/scripts/index_scripts/requirements.txt",
+    "postStartCommand": "git pull origin main && python3 -m pip install -r infra/scripts/index_scripts/requirements.txt",
     "remoteUser": "vscode",
     "hostRequirements": {
-        "memory": "8gb"
+        "memory": "4gb"
     }
 }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please check the link [Azure Products by Region](https://azure.microsoft.com/en-
 
 -  Azure region where the resources will be created in
 
--  Environment name, a 3-10 characters alphanumeric value that will be used to prefix resources
+-  Environment name, a 3-20 characters alphanumeric value that will be used to prefix resources
 
 -  Content Understanding location from the drop-down list of values
 
@@ -199,7 +199,7 @@ You can view the permissions for your account and subscription by following the 
 By default this template will use the environment name as the prefix to prevent naming collisions within Azure. The parameters below show the default values. You only need to run the statements below if you need to change the values. 
 
 
-> To override any of the parameters, run `azd env set <key> <value>` before running `azd up`. On the first azd command, it will prompt you for the environment name. Be sure to choose 3-10 charaters alphanumeric unique name. 
+> To override any of the parameters, run `azd env set <key> <value>` before running `azd up`. On the first azd command, it will prompt you for the environment name. Be sure to choose 3-20 charaters alphanumeric unique name. 
 
 Change the Content Understanding Location (allowed values: West US, Sweden Central, Australia East)
 

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -80,7 +80,7 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' =
     name: 'Premium'
   }
   properties: {
-    adminUserEnabled: true
+    adminUserEnabled: false
     dataEndpointEnabled: false
     networkRuleBypassOptions: 'AzureServices'
     networkRuleSet: {

--- a/infra/deploy_cosmos_db.bicep
+++ b/infra/deploy_cosmos_db.bicep
@@ -39,7 +39,7 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2022-08-15' = {
     databaseAccountOfferType: 'Standard'
     enableAutomaticFailover: false
     enableMultipleWriteLocations: false
-    disableLocalAuth: false
+    disableLocalAuth: true
     apiProperties: (kind == 'MongoDB') ? { serverVersion: '4.0' } : {}
     capabilities: [ { name: 'EnableServerless' } ]
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -2,8 +2,8 @@
 targetScope = 'resourceGroup'
 
 @minLength(3)
-@maxLength(10)
-@description('A unique prefix for all resources in this deployment. This should be 3-10 characters long:')
+@maxLength(20)
+@description('A unique prefix for all resources in this deployment. This should be 3-20 characters long:')
 param environmentName string
 
 @minLength(1)

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,16 +5,16 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "6443985593110817960"
+      "templateHash": "770098073876871961"
     }
   },
   "parameters": {
     "environmentName": {
       "type": "string",
       "minLength": 3,
-      "maxLength": 10,
+      "maxLength": 20,
       "metadata": {
-        "description": "A unique prefix for all resources in this deployment. This should be 3-10 characters long:"
+        "description": "A unique prefix for all resources in this deployment. This should be 3-20 characters long:"
       }
     },
     "contentUnderstandingLocation": {
@@ -366,7 +366,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "12900062765650369722"
+              "templateHash": "16302841985782460131"
             }
           },
           "parameters": {
@@ -540,7 +540,7 @@
                 "name": "Premium"
               },
               "properties": {
-                "adminUserEnabled": true,
+                "adminUserEnabled": false,
                 "dataEndpointEnabled": false,
                 "networkRuleBypassOptions": "AzureServices",
                 "networkRuleSet": {
@@ -1250,7 +1250,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "3100365088410602500"
+              "templateHash": "12347068855899407617"
             }
           },
           "parameters": {
@@ -1339,7 +1339,7 @@
                 "databaseAccountOfferType": "Standard",
                 "enableAutomaticFailover": false,
                 "enableMultipleWriteLocations": false,
-                "disableLocalAuth": false,
+                "disableLocalAuth": true,
                 "apiProperties": "[if(equals(parameters('kind'), 'MongoDB'), createObject('serverVersion', '4.0'), createObject())]",
                 "capabilities": [
                   {
@@ -2363,7 +2363,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "5835426116727035307"
+              "templateHash": "11186995242820167426"
             }
           },
           "parameters": {
@@ -2498,7 +2498,7 @@
           },
           "variables": {
             "WebAppImageName": "[format('DOCKER|kmcontainerreg.azurecr.io/km-app:{0}', parameters('imageTag'))]",
-            "REACT_APP_LAYOUT_CONFIG": "{\r\n  \"appConfig\": {\r\n    \"THREE_COLUMN\": {\r\n      \"DASHBOARD\": 50,\r\n      \"CHAT\": 33,\r\n      \"CHATHISTORY\": 17\r\n    },\r\n    \"TWO_COLUMN\": {\r\n      \"DASHBOARD_CHAT\": {\r\n        \"DASHBOARD\": 65,\r\n        \"CHAT\": 35\r\n      },\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 80,\r\n        \"CHATHISTORY\": 20\r\n      }\r\n    }\r\n  },\r\n  \"charts\": [\r\n    {\r\n      \"id\": \"SATISFIED\",\r\n      \"name\": \"Satisfied\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\r\n    },\r\n    {\r\n      \"id\": \"TOTAL_CALLS\",\r\n      \"name\": \"Total Calls\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME\",\r\n      \"name\": \"Average Handling Time\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"SENTIMENT\",\r\n      \"name\": \"Topics Overview\",\r\n      \"type\": \"donutchart\",\r\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\r\n      \"name\": \"Average Handling Time By Topic\",\r\n      \"type\": \"bar\",\r\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\r\n    },\r\n    {\r\n      \"id\": \"TOPICS\",\r\n      \"name\": \"Trending Topics\",\r\n      \"type\": \"table\",\r\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\r\n    },\r\n    {\r\n      \"id\": \"KEY_PHRASES\",\r\n      \"name\": \"Key Phrases\",\r\n      \"type\": \"wordcloud\",\r\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\r\n    }\r\n  ]\r\n}"
+            "REACT_APP_LAYOUT_CONFIG": "{\n  \"appConfig\": {\n    \"THREE_COLUMN\": {\n      \"DASHBOARD\": 50,\n      \"CHAT\": 33,\n      \"CHATHISTORY\": 17\n    },\n    \"TWO_COLUMN\": {\n      \"DASHBOARD_CHAT\": {\n        \"DASHBOARD\": 65,\n        \"CHAT\": 35\n      },\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 80,\n        \"CHATHISTORY\": 20\n      }\n    }\n  },\n  \"charts\": [\n    {\n      \"id\": \"SATISFIED\",\n      \"name\": \"Satisfied\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\n    },\n    {\n      \"id\": \"TOTAL_CALLS\",\n      \"name\": \"Total Calls\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME\",\n      \"name\": \"Average Handling Time\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\n    },\n    {\n      \"id\": \"SENTIMENT\",\n      \"name\": \"Topics Overview\",\n      \"type\": \"donutchart\",\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\n      \"name\": \"Average Handling Time By Topic\",\n      \"type\": \"bar\",\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\n    },\n    {\n      \"id\": \"TOPICS\",\n      \"name\": \"Trending Topics\",\n      \"type\": \"table\",\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\n    },\n    {\n      \"id\": \"KEY_PHRASES\",\n      \"name\": \"Key Phrases\",\n      \"type\": \"wordcloud\",\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\n    }\n  ]\n}"
           },
           "resources": [
             {


### PR DESCRIPTION
## Purpose
This pull request includes several changes across multiple files to update configurations and improve security. The most important changes include updating the environment name length, modifying admin user settings, and changing authentication settings.

[Bug 14684](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/14684): [GitHub] [#248] - Bug - KM Generic- Resource name too long / env name 10 characters constraint is too low
[Bug 14683](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/14683): [BugBash] - Feedback - KM Generic- Policy violation for CosmosDB and ACR
[Bug 14682](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/14682): [GitHub] [#247] - Bug - KM Generic- MacOS Dev Container configuration requires 8gb of RAM, more than my Macbook Pro M2 has available
[Bug 14650](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/14650): [BugBash] - Feedback - KM Generic- Automatic pulling latest code from repo is not working with VS code deployment

### Configuration Updates:
* Updated the environment name length to allow 3-20 characters instead of 3-10 characters in `README.md`, `infra/main.bicep`, and `infra/main.json`. 

### Security Improvements:
* Disabled the admin user in `infra/deploy_ai_foundry.bicep` and `infra/main.json` to enhance security. 

### Miscellaneous:
* Changed `postCreateCommand` to `postStartCommand` and reduced memory requirement in `.devcontainer/devcontainer.json`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## Other Information

<!-- Add any other helpful information that may be needed here. -->

