### PR TITLE
fix: AI Services like CU custom endpoint URI

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -14,7 +14,7 @@ param managedIdentityObjectId string
 var storageName = '${solutionName}hubstorage'
 var storageSkuName = 'Standard_LRS'
 var aiServicesName = '${solutionName}-aiservices'
-var aiServicesName_cu = '${solutionName}-aiservices_cu'
+var aiServicesName_cu = '${solutionName}-aiservices-cu'
 var location_cu = cuLocation
 // var aiServicesName_m = '${solutionName}-aiservices_m'
 // var location_m = solutionLocation
@@ -201,7 +201,7 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2021-10-01' = {
 //   }
 // }
 
-resource aiServices_CU 'Microsoft.CognitiveServices/accounts@2021-10-01' = {
+resource aiServices_CU 'Microsoft.CognitiveServices/accounts@2024-04-01-preview' = {
   name: aiServicesName_cu
   location: location_cu
   sku: {
@@ -209,6 +209,7 @@ resource aiServices_CU 'Microsoft.CognitiveServices/accounts@2021-10-01' = {
   }
   kind: 'AIServices'
   properties: {
+    customSubDomainName: aiServicesName_cu
     apiProperties: {
       statisticsEnabled: false
     }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "770098073876871961"
+      "templateHash": "126835841607797415"
     }
   },
   "parameters": {
@@ -366,7 +366,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "16302841985782460131"
+              "templateHash": "16925264059668982974"
             }
           },
           "parameters": {
@@ -408,8 +408,9 @@
             "storageName": "[format('{0}hubstorage', parameters('solutionName'))]",
             "storageSkuName": "Standard_LRS",
             "aiServicesName": "[format('{0}-aiservices', parameters('solutionName'))]",
-            "aiServicesName_cu": "[format('{0}-aiservices_cu', parameters('solutionName'))]",
+            "aiServicesName_cu": "[format('{0}-aiservices-cu', parameters('solutionName'))]",
             "location_cu": "[parameters('cuLocation')]",
+            "workspaceName": "[format('{0}-workspace', parameters('solutionName'))]",
             "applicationInsightsName": "[format('{0}-appinsights', parameters('solutionName'))]",
             "containerRegistryName": "[format('{0}acr', parameters('solutionName'))]",
             "keyvaultName": "[format('{0}-kv', parameters('solutionName'))]",
@@ -513,6 +514,19 @@
               ]
             },
             {
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2023-09-01",
+              "name": "[variables('workspaceName')]",
+              "location": "[variables('location')]",
+              "tags": {},
+              "properties": {
+                "retentionInDays": 30,
+                "sku": {
+                  "name": "PerGB2018"
+                }
+              }
+            },
+            {
               "type": "Microsoft.Insights/components",
               "apiVersion": "2020-02-02",
               "name": "[variables('applicationInsightsName')]",
@@ -520,16 +534,13 @@
               "kind": "web",
               "properties": {
                 "Application_Type": "web",
-                "DisableIpMasking": false,
-                "DisableLocalAuth": false,
-                "Flow_Type": "Bluefield",
-                "ForceCustomerStorageForProfiler": false,
-                "ImmediatePurgeDataOn30Days": true,
-                "IngestionMode": "ApplicationInsights",
                 "publicNetworkAccessForIngestion": "Enabled",
                 "publicNetworkAccessForQuery": "Disabled",
-                "Request_Source": "rest"
-              }
+                "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('workspaceName'))]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', variables('workspaceName'))]"
+              ]
             },
             {
               "type": "Microsoft.ContainerRegistry/registries",
@@ -580,7 +591,7 @@
             },
             {
               "type": "Microsoft.CognitiveServices/accounts",
-              "apiVersion": "2021-10-01",
+              "apiVersion": "2024-04-01-preview",
               "name": "[variables('aiServicesName_cu')]",
               "location": "[variables('location_cu')]",
               "sku": {
@@ -588,6 +599,7 @@
               },
               "kind": "AIServices",
               "properties": {
+                "customSubDomainName": "[variables('aiServicesName_cu')]",
                 "apiProperties": {
                   "statisticsEnabled": false
                 }
@@ -853,7 +865,7 @@
               "apiVersion": "2021-11-01-preview",
               "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AZURE-OPENAI-CU-ENDPOINT')]",
               "properties": {
-                "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu')), '2021-10-01').endpoint]"
+                "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu')), '2024-04-01-preview').endpoint]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu'))]"
@@ -864,7 +876,7 @@
               "apiVersion": "2021-11-01-preview",
               "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AZURE-OPENAI-CU-KEY')]",
               "properties": {
-                "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu')), '2021-10-01').key1]"
+                "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu')), '2024-04-01-preview').key1]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu'))]"


### PR DESCRIPTION
## Purpose
AI Services like CU custom endpoint URI

This pull request includes several changes to the `infra` directory, specifically within the `deploy_ai_foundry.bicep` and `main.json` files. The changes focus on updating resource configurations and improving the structure of the deployment scripts. The most important changes include updating API versions, adding new resources, and modifying existing configurations.

### Updates to API versions and resource configurations:

* [`infra/deploy_ai_foundry.bicep`]: Updated the `aiServices_CU` resource to use the `2024-04-01-preview` API version and added the `customSubDomainName` property.
* [`infra/main.json`]: Updated the `aiServices_CU` resource to use the `2024-04-01-preview` API version and added the `customSubDomainName` property.

These changes ensure that the deployment scripts are up-to-date with the latest API versions and improve the overall structure and functionality of the deployment process.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.


