### PR TITLE
fix: Always execute sp_addrolemember in create-sql-user-and-role.ps1

### DIFF
--- a/infra/scripts/add_user_scripts/create-sql-user-and-role.ps1
+++ b/infra/scripts/add_user_scripts/create-sql-user-and-role.ps1
@@ -58,8 +58,8 @@ DECLARE @cmd NVARCHAR(max) = N'CREATE USER [' + @username + '] WITH SID = ' + @s
 IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = @username)
 BEGIN
     EXEC(@cmd)
-    EXEC sp_addrolemember '$($DatabaseRole)', @username;
 END
+EXEC sp_addrolemember '$($DatabaseRole)', @username;
 "@
 
 Write-Output "`nSQL:`n$($sql)`n`n"


### PR DESCRIPTION
## Purpose
This pull request includes a small change to the `infra/scripts/add_user_scripts/create-sql-user-and-role.ps1` file. The change ensures that the `sp_addrolemember` command is executed even if the user already exists.

* [`infra/scripts/add_user_scripts/create-sql-user-and-role.ps1`](diffhunk://#diff-db38659ac3a9761c5312f22f21d3cc6ec123558ac0bac26bbca5e66341b15b34L61-R62): Moved the `sp_addrolemember` command outside of the conditional block to ensure it runs regardless of whether the user already exists.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

