### PR TITLE
ci: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
    commit-message:
      prefix: "build"
    target-branch: "dependabotchanges"
-   open-pull-requests-limit: 30
+   open-pull-requests-limit: 100
 
  - package-ecosystem: "pip"
    directory: "/App"
@@ -17,7 +17,7 @@ updates:
    commit-message:
      prefix: "build"
    target-branch: "dependabotchanges"
-   open-pull-requests-limit: 60
+   open-pull-requests-limit: 100
 
  - package-ecosystem: "npm"
    directory: "/App/frontend"
@@ -26,7 +26,7 @@ updates:
    commit-message:
      prefix: "build"
    target-branch: "dependabotchanges"
-   open-pull-requests-limit: 60
+   open-pull-requests-limit: 100
    registries:
      - npm_public_registry  # Only use public npm registry
 


### PR DESCRIPTION
## Purpose
This pull request includes changes to the `.github/dependabot.yml` file to increase the limit on open pull requests for different package ecosystems. 

Changes to open pull requests limit:

* Increased the `open-pull-requests-limit` for the `pip` package ecosystem from 30 to 100.
* Increased the `open-pull-requests-limit` for the `npm` package ecosystem in the `/App/frontend` directory from 60 to 100.
* Increased the `open-pull-requests-limit` for the `npm` package ecosystem with the `npm_public_registry` registry from 60 to 100.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

