### PR TITLE
fix: Utilize Secondary Locations for Deployment Scripts

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -159,7 +159,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
 module uploadFiles 'deploy_upload_files_script.bicep' = {
   name : 'deploy_upload_files_script'
   params:{
-    solutionLocation: solutionLocation
+    solutionLocation: secondaryLocation
     baseUrl: baseUrl
     storageAccountName: storageAccount.outputs.storageName
     containerName: storageAccount.outputs.storageContainer
@@ -172,7 +172,7 @@ module uploadFiles 'deploy_upload_files_script.bicep' = {
 module createIndex 'deploy_index_scripts.bicep' = {
   name : 'deploy_index_scripts'
   params:{
-    solutionLocation: solutionLocation
+    solutionLocation: secondaryLocation
     identity:managedIdentityModule.outputs.managedIdentityOutput.id
     baseUrl:baseUrl
     keyVaultName:aifoundry.outputs.keyvaultName

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17140771814245764407"
+      "templateHash": "15699139662875746088"
     }
   },
   "parameters": {
@@ -1569,7 +1569,7 @@
         "mode": "Incremental",
         "parameters": {
           "solutionLocation": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('secondaryLocation')]"
           },
           "baseUrl": {
             "value": "[variables('baseUrl')]"
@@ -1655,7 +1655,7 @@
         "mode": "Incremental",
         "parameters": {
           "solutionLocation": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('secondaryLocation')]"
           },
           "identity": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_managed_identity'), '2022-09-01').outputs.managedIdentityOutput.value.id]"


### PR DESCRIPTION
## Purpose

This pull request includes changes to update the parameter `solutionLocation` to `secondaryLocation` in multiple Bicep and JSON files. The most important changes are as follows:

Parameter updates in Bicep files:

* [`infra/main.bicep`]: Updated `solutionLocation` to `secondaryLocation` in the `uploadFiles` module parameters.
* [`infra/main.bicep`]: Updated `solutionLocation` to `secondaryLocation` in the `createIndex` module parameters.

Parameter updates in JSON files:

* [`infra/main.json`]: Updated `solutionLocation` to `secondaryLocation` in the parameters section for deployment mode `Incremental`.
* [`infra/main.json`]: Updated `solutionLocation` to `secondaryLocation` in another parameters section for deployment mode `Incremental`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.