### PR TITLE
fix: Update Content Understanding Service Location & Rename gptModelVersion to azureOpenAIApiVersion Across Files

### DIFF
--- a/.github/workflows/deploy-KMGeneric.yml
+++ b/.github/workflows/deploy-KMGeneric.yml
@@ -112,7 +112,7 @@ jobs:
           az deployment group create \
             --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
             --template-file infra/main.bicep \
-            --parameters environmentName=${{env.SOLUTION_PREFIX}} contentUnderstandingLocation="westus" secondaryLocation="${{ env.AZURE_LOCATION }}" imageTag=${{ steps.determine_tag.outputs.tagname }}
+            --parameters environmentName=${{env.SOLUTION_PREFIX}} contentUnderstandingLocation="swedencentral" secondaryLocation="${{ env.AZURE_LOCATION }}" imageTag=${{ steps.determine_tag.outputs.tagname }}
      
             
       - name: Extract AI Services and Key Vault Names

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When you start the deployment, most parameters will have **default values**, but
 |------------|----------------|  ------------|
 | **Azure Region** | The region where resources will be created. | East US| 
 | **Environment Name** | A **3-20 character alphanumeric value** used to generate a unique ID to prefix the resources. |  kmtemplate |
-| **Content Understanding Location** | Select from a drop-down list of values. |  West US |
+| **Content Understanding Location** | Select from a drop-down list of values. |  Sweden Central |
 | **Secondary Location** | A **less busy** region for **Azure SQL and CosmosDB**, useful in case of availability constraints. |  eastus2 |
 | **Deployment Type** | Select from a drop-down list. |  GlobalStandard |
 | **GPT Model** | Choose from **gpt-4, gpt-4o, gpt-4o-mini** | gpt-4o-mini |  

--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -5,10 +5,10 @@ By default this template will use the environment name as the prefix to prevent 
 
 > To override any of the parameters, run `azd env set <key> <value>` before running `azd up`. On the first azd command, it will prompt you for the environment name. Be sure to choose 3-20 charaters alphanumeric unique name. 
 
-Change the Content Understanding Location (allowed values: West US, Sweden Central, Australia East)
+Change the Content Understanding Location (allowed values: Sweden Central, Australia East)
 
 ```shell
-azd env set AZURE_ENV_CU_LOCATION 'westus'
+azd env set AZURE_ENV_CU_LOCATION 'swedencentral'
 ```
 
 Change the Secondary Location (example: eastus2, westus2, etc.)

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -5,7 +5,7 @@ param keyVaultName string
 param cuLocation string
 param deploymentType string
 param gptModelName string
-param gptModelVersion string
+param azureOpenAIApiVersion string
 param gptDeploymentCapacity int
 param embeddingModel string
 param embeddingDeploymentCapacity int
@@ -531,7 +531,7 @@ resource azureOpenAIApiVersionEntry 'Microsoft.KeyVault/vaults/secrets@2021-11-0
   parent: keyVault
   name: 'AZURE-OPENAI-PREVIEW-API-VERSION'
   properties: {
-    value: gptModelVersion  //'2024-02-15-preview'
+    value: azureOpenAIApiVersion  //'2024-02-15-preview'
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -8,8 +8,7 @@ param environmentName string
 
 @minLength(1)
 @description('Location for the Content Understanding service deployment:')
-@allowed(['westus'
-'swedencentral' 
+@allowed(['swedencentral' 
 'australiaeast'
 ])
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -43,7 +43,7 @@ param gptModelName string = 'gpt-4o-mini'
 // @minLength(1)
 // @description('Version of the GPT model to deploy:')
 // param gptModelVersion string = '2024-02-15-preview' //'2024-08-06'
-var gptModelVersion = '2024-02-15-preview'
+var azureOpenAIApiVersion = '2024-02-15-preview'
 
 @minValue(10)
 @description('Capacity of the GPT deployment:')
@@ -105,7 +105,7 @@ module aifoundry 'deploy_ai_foundry.bicep' = {
     cuLocation: contentUnderstandingLocation
     deploymentType: deploymentType
     gptModelName: gptModelName
-    gptModelVersion: gptModelVersion
+    azureOpenAIApiVersion: azureOpenAIApiVersion
     gptDeploymentCapacity: gptDeploymentCapacity
     embeddingModel: embeddingModel
     embeddingDeploymentCapacity: embeddingDeploymentCapacity
@@ -208,7 +208,7 @@ module azureragFunctionsRag 'deploy_azure_function_rag.bicep' = {
     azureOpenAIDeploymentModel:gptModelName
     azureSearchAdminKey:keyVault.getSecret('AZURE-SEARCH-KEY')
     azureSearchServiceEndpoint:aifoundry.outputs.aiSearchTarget
-    azureOpenAIApiVersion: gptModelVersion //'2024-02-15-preview'
+    azureOpenAIApiVersion: azureOpenAIApiVersion
     azureAiProjectConnString:keyVault.getSecret('AZURE-AI-PROJECT-CONN-STRING')
     azureSearchIndex:'call_transcripts_index'
     sqlServerName:sqlDBModule.outputs.sqlServerName
@@ -243,7 +243,7 @@ module appserviceModule 'deploy_app_service.bicep' = {
     AzureOpenAIEndpoint:aifoundry.outputs.aiServicesTarget
     AzureOpenAIModel: gptModelName //'gpt-4o-mini'
     AzureOpenAIKey:keyVault.getSecret('AZURE-OPENAI-KEY')
-    azureOpenAIApiVersion: gptModelVersion //'2024-02-15-preview'
+    azureOpenAIApiVersion: azureOpenAIApiVersion
     AZURE_OPENAI_RESOURCE:aifoundry.outputs.aiServicesName
     CHARTS_URL:azureFunctionURL.outputs.functionURLsOutput.charts_function_url
     FILTERS_URL:azureFunctionURL.outputs.functionURLsOutput.filters_function_url

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,7 +1,7 @@
 using './main.bicep'
 
 param environmentName = readEnvironmentVariable('AZURE_ENV_NAME', 'env_name')
-param contentUnderstandingLocation = readEnvironmentVariable('AZURE_ENV_CU_LOCATION', 'westus')
+param contentUnderstandingLocation = readEnvironmentVariable('AZURE_ENV_CU_LOCATION', 'swedencentral')
 param secondaryLocation = readEnvironmentVariable('AZURE_ENV_SECONDARY_LOCATION', 'eastus2')
 param deploymentType = readEnvironmentVariable('AZURE_ENV_MODEL_DEPLOYMENT_TYPE', 'GlobalStandard')
 param gptModelName = readEnvironmentVariable('AZURE_ENV_MODEL_NAME', 'gpt-4o-mini')

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "6137238321359558361"
+      "templateHash": "11681606312393631861"
     }
   },
   "parameters": {
@@ -96,7 +96,7 @@
     }
   },
   "variables": {
-    "gptModelVersion": "2024-02-15-preview",
+    "azureOpenAIApiVersion": "2024-02-15-preview",
     "uniqueId": "[toLower(uniqueString(subscription().id, parameters('environmentName'), resourceGroup().location))]",
     "solutionPrefix": "[format('km{0}', padLeft(take(variables('uniqueId'), 12), 12, '0'))]",
     "resourceGroupLocation": "[resourceGroup().location]",
@@ -342,8 +342,8 @@
           "gptModelName": {
             "value": "[parameters('gptModelName')]"
           },
-          "gptModelVersion": {
-            "value": "[variables('gptModelVersion')]"
+          "azureOpenAIApiVersion": {
+            "value": "[variables('azureOpenAIApiVersion')]"
           },
           "gptDeploymentCapacity": {
             "value": "[parameters('gptDeploymentCapacity')]"
@@ -365,7 +365,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "12181740834683882986"
+              "templateHash": "1675749319689275164"
             }
           },
           "parameters": {
@@ -387,7 +387,7 @@
             "gptModelName": {
               "type": "string"
             },
-            "gptModelVersion": {
+            "azureOpenAIApiVersion": {
               "type": "string"
             },
             "gptDeploymentCapacity": {
@@ -787,7 +787,7 @@
               "apiVersion": "2021-11-01-preview",
               "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AZURE-OPENAI-PREVIEW-API-VERSION')]",
               "properties": {
-                "value": "[parameters('gptModelVersion')]"
+                "value": "[parameters('azureOpenAIApiVersion')]"
               }
             },
             {
@@ -1940,7 +1940,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchTarget.value]"
           },
           "azureOpenAIApiVersion": {
-            "value": "[variables('gptModelVersion')]"
+            "value": "[variables('azureOpenAIApiVersion')]"
           },
           "azureAiProjectConnString": {
             "reference": {
@@ -2280,7 +2280,7 @@
             }
           },
           "azureOpenAIApiVersion": {
-            "value": "[variables('gptModelVersion')]"
+            "value": "[variables('azureOpenAIApiVersion')]"
           },
           "AZURE_OPENAI_RESOURCE": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiServicesName.value]"
@@ -2323,7 +2323,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "11186995242820167426"
+              "templateHash": "5835426116727035307"
             }
           },
           "parameters": {
@@ -2458,7 +2458,7 @@
           },
           "variables": {
             "WebAppImageName": "[format('DOCKER|kmcontainerreg.azurecr.io/km-app:{0}', parameters('imageTag'))]",
-            "REACT_APP_LAYOUT_CONFIG": "{\n  \"appConfig\": {\n    \"THREE_COLUMN\": {\n      \"DASHBOARD\": 50,\n      \"CHAT\": 33,\n      \"CHATHISTORY\": 17\n    },\n    \"TWO_COLUMN\": {\n      \"DASHBOARD_CHAT\": {\n        \"DASHBOARD\": 65,\n        \"CHAT\": 35\n      },\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 80,\n        \"CHATHISTORY\": 20\n      }\n    }\n  },\n  \"charts\": [\n    {\n      \"id\": \"SATISFIED\",\n      \"name\": \"Satisfied\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\n    },\n    {\n      \"id\": \"TOTAL_CALLS\",\n      \"name\": \"Total Calls\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME\",\n      \"name\": \"Average Handling Time\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\n    },\n    {\n      \"id\": \"SENTIMENT\",\n      \"name\": \"Topics Overview\",\n      \"type\": \"donutchart\",\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\n      \"name\": \"Average Handling Time By Topic\",\n      \"type\": \"bar\",\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\n    },\n    {\n      \"id\": \"TOPICS\",\n      \"name\": \"Trending Topics\",\n      \"type\": \"table\",\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\n    },\n    {\n      \"id\": \"KEY_PHRASES\",\n      \"name\": \"Key Phrases\",\n      \"type\": \"wordcloud\",\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\n    }\n  ]\n}"
+            "REACT_APP_LAYOUT_CONFIG": "{\r\n  \"appConfig\": {\r\n    \"THREE_COLUMN\": {\r\n      \"DASHBOARD\": 50,\r\n      \"CHAT\": 33,\r\n      \"CHATHISTORY\": 17\r\n    },\r\n    \"TWO_COLUMN\": {\r\n      \"DASHBOARD_CHAT\": {\r\n        \"DASHBOARD\": 65,\r\n        \"CHAT\": 35\r\n      },\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 80,\r\n        \"CHATHISTORY\": 20\r\n      }\r\n    }\r\n  },\r\n  \"charts\": [\r\n    {\r\n      \"id\": \"SATISFIED\",\r\n      \"name\": \"Satisfied\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\r\n    },\r\n    {\r\n      \"id\": \"TOTAL_CALLS\",\r\n      \"name\": \"Total Calls\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME\",\r\n      \"name\": \"Average Handling Time\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"SENTIMENT\",\r\n      \"name\": \"Topics Overview\",\r\n      \"type\": \"donutchart\",\r\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\r\n      \"name\": \"Average Handling Time By Topic\",\r\n      \"type\": \"bar\",\r\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\r\n    },\r\n    {\r\n      \"id\": \"TOPICS\",\r\n      \"name\": \"Trending Topics\",\r\n      \"type\": \"table\",\r\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\r\n    },\r\n    {\r\n      \"id\": \"KEY_PHRASES\",\r\n      \"name\": \"Key Phrases\",\r\n      \"type\": \"wordcloud\",\r\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\r\n    }\r\n  ]\r\n}"
           },
           "resources": [
             {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "15699139662875746088"
+      "templateHash": "6137238321359558361"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
     "contentUnderstandingLocation": {
       "type": "string",
       "allowedValues": [
-        "westus",
         "swedencentral",
         "australiaeast"
       ],


### PR DESCRIPTION
This pull request includes changes to update the location for the Content Understanding service and to rename the `gptModelVersion` parameter to `azureOpenAIApiVersion` across multiple files. The most important changes include updates to the deployment scripts, documentation, and infrastructure files.

### Updates to Content Understanding Location:

* [`.github/workflows/deploy-KMGeneric.yml`]: Changed `contentUnderstandingLocation` from `westus` to `swedencentral`.
* [`README.md`]: Updated the default value for `Content Understanding Location` from `West US` to `Sweden Central`.
* [`docs/CustomizingAzdParameters.md`]: Updated allowed values for `Content Understanding Location` and example command to use `swedencentral`.
* [`infra/main.bicepparam`]: Updated `contentUnderstandingLocation` default value to `swedencentral`.
* [`infra/main.json`]: Removed `westus` from allowed values for `contentUnderstandingLocation`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
