### PR TITLE
fix: Update Tag in Validate Deployment - KM Generic

### DIFF
--- a/.github/workflows/deploy-KMGeneric.yml
+++ b/.github/workflows/deploy-KMGeneric.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Determine Tag Name Based on Branch
         id: determine_tag
-        run: echo "tagname=${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'dev' && 'dev' || github.ref_name == 'demo' && 'demo' || github.ref_name == 'dependabotchanges' && 'dependabotchanges' || github.head_ref || 'default' }}" >> $GITHUB_OUTPUT
+        run: echo "tagname=${{ github.ref_name == 'main' && 'latest_migra' || github.ref_name == 'dev' && 'dev' || github.ref_name == 'demo' && 'demo' || github.ref_name == 'dependabotchanges' && 'dependabotchanges' || github.head_ref || 'default' }}" >> $GITHUB_OUTPUT
 
       - name: Deploy Bicep Template
         id: deploy


### PR DESCRIPTION
## Purpose
This pull request includes a change to the `.github/workflows/deploy-KMGeneric.yml` file to modify the tag name determination logic.

* [`.github/workflows/deploy-KMGeneric.yml`](diffhunk://#diff-d89c1a2a54c3fecc22cbfae6dc62ebdfeb753cd82c7192b447c07e8235242d75L106-R106): Changed the tag name for the 'main' branch from 'latest' to 'latest_migra' in the `Determine Tag Name Based on Branch` step.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

