### PR TITLE
fix: Remove parameters and deployment configuration in  azure.yaml 

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,25 +8,6 @@ name: conversation-knowledge-mining
 metadata:
   template: conversation-knowledge-mining@1.0
 
-parameters:
-  solutionPrefix:
-    type: string
-    default: bs-azdtest  
-  otherLocation:
-    type: string
-    default: eastus2
-  baseUrl:
-    type: string
-    default: 'https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/'
-
-deployment:
-  mode: Incremental
-  template: ./infra/main.bicep  # Path to the main.bicep file inside the 'deployment' folder
-  parameters:
-    solutionPrefix: ${parameters.solutionPrefix}
-    otherLocation: ${parameters.otherLocation}
-    baseUrl: ${parameters.baseUrl}
-
 hooks:
   postprovision:
     windows:


### PR DESCRIPTION
## Purpose
This pull request includes significant changes to the `azure.yaml` file for the `conversation-knowledge-mining` configuration. The changes primarily involve the removal of parameters and deployment configuration.

Key changes:

* Removed `parameters` section, including `solutionPrefix`, `otherLocation`, and `baseUrl` definitions.
* Removed `deployment` section, including the mode, template path, and parameter mappings.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.