### PR TITLE
fix: remove parameters and the deployment section in azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,25 +8,6 @@ name: conversation-knowledge-mining
 metadata:
   template: conversation-knowledge-mining@1.0
 
-parameters:
-  solutionPrefix:
-    type: string
-    default: bs-azdtest  
-  otherLocation:
-    type: string
-    default: eastus2
-  baseUrl:
-    type: string
-    default: 'https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/'
-
-deployment:
-  mode: Incremental
-  template: ./infra/main.bicep  # Path to the main.bicep file inside the 'deployment' folder
-  parameters:
-    solutionPrefix: ${parameters.solutionPrefix}
-    otherLocation: ${parameters.otherLocation}
-    baseUrl: ${parameters.baseUrl}
-
 hooks:
   postprovision:
     windows:


### PR DESCRIPTION
## Purpose
This pull request includes a significant change to the `azure.yaml` file, specifically the removal of several parameters and the deployment section. Below is a summary of the most important changes:

Configuration simplification:

* [`azure.yaml`](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L11-L29): Removed the `parameters` section, which included `solutionPrefix`, `otherLocation`, and `baseUrl` settings.
* [`azure.yaml`](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L11-L29): Removed the `deployment` section, which defined the deployment mode and template path, along with the parameters for the deployment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

