### PR TITLE
fix: disable purge protection of key vault

### DIFF
--- a/infra/deploy_keyvault.bicep
+++ b/infra/deploy_keyvault.bicep
@@ -36,7 +36,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     enabledForDiskEncryption: true
     enabledForTemplateDeployment: true
     enableRbacAuthorization: true
-    enablePurgeProtection: true
     publicNetworkAccess: 'enabled'
     // networkAcls: {
     //   bypass: 'AzureServices'

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "10251291785467156580"
+      "templateHash": "12889457552620966656"
     }
   },
   "parameters": {
@@ -241,7 +241,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "5775352776365113688"
+              "templateHash": "12651362851097406702"
             }
           },
           "parameters": {
@@ -295,7 +295,6 @@
                 "enabledForDiskEncryption": true,
                 "enabledForTemplateDeployment": true,
                 "enableRbacAuthorization": true,
-                "enablePurgeProtection": true,
                 "publicNetworkAccess": "enabled",
                 "sku": {
                   "family": "A",


### PR DESCRIPTION
## Purpose
This pull request makes changes to the Key Vault configuration in the Bicep and JSON deployment templates. The most significant update is the removal of the `enablePurgeProtection` property from the Key Vault configuration, along with updates to the template hash values in the generated JSON files.

### Key Vault Configuration Updates:
* Removed the `enablePurgeProtection` property from the Key Vault configuration in `deploy_keyvault.bicep` and `main.json`. This change may affect the ability to recover deleted Key Vaults or their contents. [[1]](diffhunk://#diff-82312b3acfa82a4f0980d7e0592f22b8db36f98965a61c340510f972ad7306faL39) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L298)

### Template Hash Updates:
* Updated the `templateHash` values in `infra/main.json` to reflect changes in the generated deployment template. These updates are automatically generated by the Bicep compiler. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L244-R244)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.