### PR TITLE
fix: Limiting citation content length in kernel function responses and restrict save history for error response

### DIFF
--- a/src/App/src/components/Chat/Chat.tsx
+++ b/src/App/src/components/Chat/Chat.tsx
@@ -642,7 +642,9 @@ const Chat: React.FC<ChatProps> = ({
           ];
         }
       }
-      saveToDB(updatedMessages, conversationId, isChatReq);
+      if (!updatedMessages.find((msg: any) => msg.role=== "error")) {
+        saveToDB(updatedMessages, conversationId, isChatReq);
+      }
     } catch (e) {
       console.log("Catched with an error while chat and save", e);
       if (abortController.signal.aborted) {

--- a/src/api/plugins/chat_with_data_plugin.py
+++ b/src/api/plugins/chat_with_data_plugin.py
@@ -198,12 +198,12 @@ class ChatWithDataPlugin:
                     ]
                 }
             )
-            answer = copy.deepcopy(completion.choices[0])
+            answer = completion.choices[0]
 
             # Limit the content inside citations to 300 characters to minimize load
-            if 'citations' in answer.message.context:
-                for citation in answer.message.context['citations']:
-                    if 'content' in citation:
+            if hasattr(answer.message, 'context') and 'citations' in answer.message.context:
+                for citation in answer.message.context.get('citations', []):
+                    if isinstance(citation, dict) and 'content' in citation:
                         citation['content'] = citation['content'][:300] + '...' if len(citation['content']) > 300 else citation['content']
         except BaseException:
             answer = 'Details could not be retrieved. Please try again later.'

--- a/src/api/plugins/chat_with_data_plugin.py
+++ b/src/api/plugins/chat_with_data_plugin.py
@@ -4,7 +4,6 @@ import openai
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
-import copy
 
 from common.config.config import Config
 from common.database.sqldb_service import execute_sql_query


### PR DESCRIPTION
## Purpose
This pull request introduces a couple of key improvements to error handling and response optimization in the chat application. Specifically, it ensures database updates are not attempted when an error message is present and limits the size of citation content in API responses to reduce load.

### Error handling improvements:
* [`src/App/src/components/Chat/Chat.tsx`](diffhunk://#diff-a8495413a74092724ad57e37fffa0de07c14fc3a4c605214fe3dcb5ea062f67fR645-R647): Added a check to prevent saving messages to the database if an error message is present in the `updatedMessages` array. This ensures that only valid messages are persisted.

### Response optimization:
* [`src/api/plugins/chat_with_data_plugin.py`](diffhunk://#diff-b27470a6fea7b89bec4be004dcebd0866befdbd90d775b9782006ee9c155afa1R201-R206): Added logic to truncate citation content to 300 characters in API responses. This reduces payload size and improves efficiency while preserving essential information.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
