### PR TITLE
fix: citation remains open even after deleting complete chat history 

### DIFF
--- a/src/App/src/App.tsx
+++ b/src/App/src/App.tsx
@@ -203,6 +203,7 @@ const Dashboard: React.FC = () => {
       type: actionConstants.UPDATE_APP_SPINNER_STATUS,
       payload: true,
     });
+    dispatch({  type: actionConstants.UPDATE_CITATION,payload: { activeCitation: null, showCitation: false }})
     setClearing(true);
     const response = await historyDeleteAll();
     if (!response.ok) {
@@ -355,7 +356,7 @@ const Dashboard: React.FC = () => {
             />
           </div>
         )}
-        {state.citation.showCitation && (
+        {state.citation.showCitation && state.citation.currentConversationIdForCitation !== "" && (
           <div
             style={{
               // width: `${panelWidths[panels.DASHBOARD]}%`,

--- a/src/App/src/components/ChatHistoryListItemCell/ChatHistoryListItemCell.tsx
+++ b/src/App/src/components/ChatHistoryListItemCell/ChatHistoryListItemCell.tsx
@@ -73,6 +73,11 @@ export const ChatHistoryListItemCell: React.FC<
       type: actionConstants.UPDATE_APP_SPINNER_STATUS,
       payload: true,
     });
+    if(state.citation.currentConversationIdForCitation === item.id) {
+      dispatch({  type: actionConstants.UPDATE_CITATION,payload: { activeCitation: null, showCitation: false, currentConversationIdForCitation: "" } });
+    }else{
+      dispatch({  type: actionConstants.UPDATE_CITATION,payload: { showCitation: true } });
+    }
     const response = await historyDelete(item.id);
     if (!response.ok) {
       setErrorDelete(true);

--- a/src/App/src/components/Citations/Citations.tsx
+++ b/src/App/src/components/Citations/Citations.tsx
@@ -32,7 +32,7 @@ const Citations = ({ answer, index }: Props) => {
     ) => {
         dispatch({
             type: actionConstants.UPDATE_CITATION,
-            payload: { showCitation: true, activeCitation: citation },
+            payload: { showCitation: true, activeCitation: citation, currentConversationIdForCitation: state?.selectedConversationId},
         });
     };
 

--- a/src/App/src/state/AppProvider.tsx
+++ b/src/App/src/state/AppProvider.tsx
@@ -33,8 +33,9 @@ export type AppState = {
     citations: string |null;
   };
   citation: {
-    activeCitation: any;
+    activeCitation?: any;
     showCitation: boolean;
+    currentConversationIdForCitation?: string;
   };
   chatHistory: {
     list: Conversation[];
@@ -77,6 +78,7 @@ const initialState: AppState = {
   citation: {
     activeCitation: null,
     showCitation: false,
+    currentConversationIdForCitation: '',
   },
   chatHistory: {
     list: [],
@@ -207,7 +209,7 @@ export type Action =
     }
   | {
     type: typeof actionConstants.UPDATE_CITATION;
-    payload: {activeCitation: any, showCitation: boolean};
+    payload: {activeCitation?: any, showCitation: boolean, currentConversationIdForCitation?: string};
   };
 
 export const AppContext = createContext<{

--- a/src/App/src/state/AppReducer.tsx
+++ b/src/App/src/state/AppReducer.tsx
@@ -257,8 +257,9 @@ const appReducer = (state: AppState, action: Action): AppState => {
         ...state,
         citation: {
           ...state.citation,
-          activeCitation: action.payload.activeCitation,
-          showCitation: action.payload.showCitation
+          activeCitation: action.payload.activeCitation || state.citation.activeCitation,   
+          showCitation: action.payload.showCitation,
+          currentConversationIdForCitation: action.payload?.currentConversationIdForCitation || state.citation.currentConversationIdForCitation,
         },
       };
     default:


### PR DESCRIPTION

## Purpose
Citation remains open even after deleting complete chat history

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## What to Check
Deploy KM Generic
Generate chat history, ask such question, where in response you will get some citations. (ask questions from below list.)
Total number of calls by date for last 7 days
Generate Chart
Show average handling time by topics in minutes
What are top 7 challenges user reported
Give a summary of billing issues
When customers call in about unexpected charges, what types of charges are they seeing?
Open any citation link, open Chat history panel as well, now total 4 sections are open
In chat history delete complete chat history
Observe that opened citation remains open.
