### PR TITLE
fix: If starting a new chat, citation panel should get closed automatically.

### DIFF
--- a/src/App/src/components/Chat/Chat.tsx
+++ b/src/App/src/components/Chat/Chat.tsx
@@ -718,6 +718,7 @@ const Chat: React.FC<ChatProps> = ({
 
   const onNewConversation = () => {
     dispatch({ type: actionConstants.NEW_CONVERSATION_START });
+    dispatch({  type: actionConstants.UPDATE_CITATION,payload: { activeCitation: null, showCitation: false }})
   };
   const { messages, citations } = state.chat;
   return (


### PR DESCRIPTION
## Purpose
If starting a new chat, citation panel should get closed automatically.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## What to Check

- Deploy KM Generic
- Create Chat history
- Open a chat history from which open a citation link (citation panel will be opened)
- now click on new chat, (+ icon)
- Citation panel should get closed. 

