### PR TITLE
fix: Chat History Fails to Save After Receiving Error (e.g., Rate Limit Error), Even When Valid Response is Received Afterwards

### DIFF
--- a/src/App/src/components/Chat/Chat.tsx
+++ b/src/App/src/components/Chat/Chat.tsx
@@ -642,7 +642,7 @@ const Chat: React.FC<ChatProps> = ({
           ];
         }
       }
-      if (!updatedMessages.find((msg: any) => msg.role=== "error")) {
+      if (updatedMessages[updatedMessages.length-1]?.role !== "error") {
         saveToDB(updatedMessages, conversationId, isChatReq);
       }
     } catch (e) {


### PR DESCRIPTION
## Purpose
Chat History Fails to Save After Receiving Error (e.g., Rate Limit Error), Even When Valid Response is Received Afterwards

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check

- Deploy KM Generic
- Open application
- Once dashboard loads properly
- Ask some questions in chat: "Total number of calls by date for last 7 days"
- After asking few questions you may receive an error message saying: "Rate limit exceeded. Try again in 7 seconds"
- Ask the same question again: "Total number of calls by date for last 7 days"
- After you get the proper response just refresh the page and open the chat history thread for this previous chat. 
- Observe and verify if chat history is getting saved or not?
- If it's getting saved, check if there is history for question asked after the Error message or not. 

