### PR TITLE
fix:  Removal of App `.env` from the ignore list

### DIFF
--- a/src/App/.dockerignore
+++ b/src/App/.dockerignore
@@ -9,7 +9,6 @@
 **/.venv
 **/.classpath
 **/.dockerignore
-**/.env
 **/.git
 **/.gitignore
 **/.project
@@ -119,7 +118,6 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
 .venv
 env/
 venv/


### PR DESCRIPTION
## Purpose
This pull request makes updates to the `.dockerignore` file in the `src/App` directory to refine the list of ignored files and directories. The primary change is the removal of `.env` from the ignore list.

Updates to `.dockerignore`:

* Removed `.env` from the ignore list in the root section of the `.dockerignore` file. This change ensures that `.env` files are no longer excluded from Docker build contexts.
* Removed `.env` from the "Environments" section of the `.dockerignore` file, aligning with the decision to include `.env` files in Docker operations.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.


