### PR TITLE
fix: Ensure the environment setup script runs after the container starts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
             ]
         }
     },
-    "postCreateCommand": "bash ./.devcontainer/setup_env.sh",
+    "postStartCommand": "bash ./.devcontainer/setup_env.sh",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "4gb"


### PR DESCRIPTION
## Purpose
This pull request makes a small adjustment to the `.devcontainer/devcontainer.json` file, changing the `postCreateCommand` to `postStartCommand` to ensure the environment setup script runs after the container starts instead of after its creation.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.


