### PR TITLE
fix: Hide citation panel logic on click of hide chat

### DIFF
--- a/src/App/src/App.tsx
+++ b/src/App/src/App.tsx
@@ -156,6 +156,7 @@ const Dashboard: React.FC = () => {
   }, [state.config.appConfig]);
 
   const onHandlePanelStates = (panelName: string) => {
+    dispatch({  type: actionConstants.UPDATE_CITATION,payload: { activeCitation: null, showCitation: false }})
     setLayoutWidthUpdated((prevFlag) => !prevFlag);
     const newState = {
       ...panelShowStates,


### PR DESCRIPTION
## Purpose
Citation panel remains visible after hiding chat

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check

1. Navigate to the KM Generic web application.
2. Interact with the chat by asking a few questions until citation links appear.
3. Click on any citation link to open the citation panel.
4. Click the "Hide Chat" button.

## Other Information

<!-- Add any other helpful information that may be needed here. -->

