### PR TITLE
fix: Add Azure CLI to Dev Container and Add Script Permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
     "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
     "forwardPorts": [50505],
     "features": {
-        "ghcr.io/azure/azure-dev/azd:latest": {}
+        "ghcr.io/azure/azure-dev/azd:latest": {},
+        "ghcr.io/devcontainers/features/azure-cli:1": {}
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/setup_env.sh
+++ b/.devcontainer/setup_env.sh
@@ -6,3 +6,4 @@ git pull
 # provide execute permission to quotacheck script
 sudo chmod +x ./infra/scripts/checkquota_km.sh
 sudo chmod +x ./infra/scripts/quota_check_params.sh
+sudo chmod +x ./infra/scripts/run_process_data_scripts.sh


### PR DESCRIPTION
## Purpose
This pull request includes updates to the development container configuration and setup script to enhance functionality and streamline the environment setup process.

### Development container configuration updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-R7): Added the `azure-cli` feature to the development container configuration to enable Azure CLI support.

### Environment setup script updates:
* [`.devcontainer/setup_env.sh`](diffhunk://#diff-884be0103962fdae0355a22edc0c050cf6051ef4952a1df7d2a9bff7a0d73ed6R9): Added execute permissions for the `run_process_data_scripts.sh` script to ensure it can be executed during environment setup.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## Other Information

<!-- Add any other helpful information that may be needed here. -->

