### PR TITLE
feat: EXP environment changes for Log Analytics workspace

### DIFF
--- a/documents/CustomizingAzdParameters.md
+++ b/documents/CustomizingAzdParameters.md
@@ -46,3 +46,8 @@ Change the Embedding Deployment Capacity (choose a number based on available emb
 ```shell
 azd env set AZURE_OPENAI_EMBEDDING_MODEL_CAPACITY 80
 ```
+
+Set the Log Analytics Workspace Id if you need to reuse the existing workspace which is already existing
+```shell
+azd env set AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID '<Existing Log Analytics Workspace Id>'
+```

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -116,6 +116,8 @@ When you start the deployment, most parameters will have **default values**, but
 | **GPT Model Deployment Capacity** | Configure capacity for **GPT models**. | 30k |
 | **Embedding Model** | Default: **text-embedding-ada-002**. | text-embedding-ada-002 |
 | **Embedding Model Capacity** | Set the capacity for **embedding models**. | 80k |
+| **Existing Log analytics workspace** | To reuse the existing Log analytics workspace Id. |  |
+
 
 </details>
 

--- a/infra/deploy_post_deployment_scripts.bicep
+++ b/infra/deploy_post_deployment_scripts.bicep
@@ -17,11 +17,12 @@ param sqlDbName string
 param sqlUsers array = [
 ]
 param logAnalyticsWorkspaceResourceName string
+param logAnalyticsWorkspaceResourceGroup string
 var resourceGroupName = resourceGroup().name
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = {
   name: logAnalyticsWorkspaceResourceName
-  scope: resourceGroup()
+  scope: resourceGroup(logAnalyticsWorkspaceResourceGroup)
 }
 
 resource containerAppEnv 'Microsoft.App/managedEnvironments@2022-03-01' = {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -6,6 +6,9 @@ var abbrs = loadJsonContent('./abbreviations.json')
 @description('A unique prefix for all resources in this deployment. This should be 3-20 characters long:')
 param environmentName string
 
+@description('Optional: Existing Log Analytics Workspace Resource ID')
+param existingLogAnalyticsWorkspaceId string = ''
+
 @minLength(1)
 @description('Location for the Content Understanding service deployment:')
 @allowed(['swedencentral', 'australiaeast'])
@@ -107,6 +110,8 @@ module aifoundry 'deploy_ai_foundry.bicep' = {
     embeddingModel: embeddingModel
     embeddingDeploymentCapacity: embeddingDeploymentCapacity
     managedIdentityObjectId: managedIdentityModule.outputs.managedIdentityOutput.objectId
+    existingLogAnalyticsWorkspaceId: existingLogAnalyticsWorkspaceId
+
   }
   scope: resourceGroup(resourceGroup().name)
 }
@@ -168,6 +173,7 @@ module uploadFiles 'deploy_post_deployment_scripts.bicep' = {
     managedIdentityClientId:managedIdentityModule.outputs.managedIdentityOutput.clientId
     keyVaultName:aifoundry.outputs.keyvaultName
     logAnalyticsWorkspaceResourceName: aifoundry.outputs.logAnalyticsWorkspaceResourceName
+    logAnalyticsWorkspaceResourceGroup: aifoundry.outputs.logAnalyticsWorkspaceResourceGroup
     sqlServerName: sqlDBModule.outputs.sqlServerName
     sqlDbName: sqlDBModule.outputs.sqlDbName
     sqlUsers: [

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -9,3 +9,4 @@ param gptModelName = readEnvironmentVariable('AZURE_OPEN_AI_DEPLOYMENT_MODEL', '
 param gptDeploymentCapacity = int(readEnvironmentVariable('AZURE_OPEN_AI_DEPLOYMENT_MODEL_CAPACITY', '30'))
 param embeddingModel = readEnvironmentVariable('AZURE_OPENAI_EMBEDDING_MODEL', 'text-embedding-ada-002')
 param embeddingDeploymentCapacity = int(readEnvironmentVariable('AZURE_OPENAI_EMBEDDING_MODEL_CAPACITY', '80'))
+param existingLogAnalyticsWorkspaceId = readEnvironmentVariable('AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID', '')


### PR DESCRIPTION
## Purpose
This pull request introduces support for reusing an existing Log Analytics Workspace during deployment. Key changes include updates to documentation, infrastructure templates, and parameter handling to enable this functionality.

### Documentation Updates:
* [`documents/CustomizingAzdParameters.md`](diffhunk://#diff-2e319e20f66e2cd84d3764f457565dbc3fe39c15edc9d7c05801ff16c423598aR49-R53): Added instructions for setting the `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID` environment variable to reuse an existing Log Analytics Workspace.
* [`documents/DeploymentGuide.md`](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5R119-R120): Updated the deployment guide to include the new parameter for specifying an existing Log Analytics Workspace.

### Infrastructure Template Enhancements:
* [`infra/deploy_ai_foundry.bicep`](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R13-R14): Introduced logic to check if an existing Log Analytics Workspace ID is provided. If so, the workspace is reused; otherwise, a new one is created. Updated resource definitions and outputs accordingly. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R13-R14) [[2]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R78-R91) [[3]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L100-R111) [[4]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L717-R730)
* [`infra/deploy_post_deployment_scripts.bicep`](diffhunk://#diff-c2a48f2bb215341bcd00f0d65153079d9ff6ca3489164d0e3196160c6f6e3a49R20-R25): Updated the scope of the existing Log Analytics Workspace resource to use the specified resource group when reusing a workspace.

### Parameter Handling:
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R9-R11): Added the `existingLogAnalyticsWorkspaceId` parameter and passed it to relevant modules for deployment. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R9-R11) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R113-R114) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R176)
* [`infra/main.bicepparam`](diffhunk://#diff-c274a6091f4ca06948f0fe1ab8681ec4eb6b4e98c4be09717a2e3cacd1344727R12): Enabled reading the `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID` environment variable to support the new functionality.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.


