### PR TITLE
feat: EXP environment changes for Existing Fabric workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Simple deploy
       
        -  Location - location of resources, by default it will use the resource group's location
            
-2.  **Create Fabric workspace**
+2.  **Create or Use an Existing Microsoft Fabric Workspace**
+
+    > ℹ️ Note: If you already have an existing Microsoft Fabric Workspace, you can **skip this step** and proceed to step 3. To retrieve an existing Workspace ID, check **Point v below**.
     1.  Navigate to ([Fabric Workspace](https://app.fabric.microsoft.com/))
     2.  Click on Workspaces from left Navigation
     3.  Click on + New Workspace
@@ -96,7 +98,7 @@ Simple deploy
          4.   ```cd ./Customer-Service-Conversational-Insights-with-Azure-OpenAI-Services/Deployment/scripts/fabric_scripts```
          5.   ```sh ./run_fabric_items_scripts.sh keyvault_param workspaceid_param solutionprefix_param```
               1.   keyvault_param - the name of the keyvault that was created in Step 1
-              2.   workspaceid_param - the workspaceid created in Step 2
+              2.   workspaceid_param - the Existing Workspaceid or workspaceid created in Step 2
               3.   solutionprefix_param - prefix used to append to lakehouse upon creation
     4.  Get Fabric Lakehouse connection details:
     5.   Once deployment is complete, navigate to Fabric Workspace


### PR DESCRIPTION
## Purpose
This pull request updates the `README.md` file to clarify instructions for deploying resources and using Microsoft Fabric Workspace. The changes aim to improve user understanding by addressing scenarios where an existing workspace can be reused.

Updates to deployment instructions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R81): Updated step 2 to allow users to either create a new Microsoft Fabric Workspace or use an existing one, including a note on how to retrieve an existing Workspace ID.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R101): Modified step 5 to specify that the `workspaceid_param` can be either an existing Workspace ID or one created in step 2.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

