### PR TITLE
fix: Point baseurl to main branch

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -65,7 +65,7 @@ var uniqueId = toLower(uniqueString(subscription().id, environmentName, solution
 var solutionPrefix = 'km${padLeft(take(uniqueId, 12), 12, '0')}'
 // var resourceGroupName = resourceGroup().name
 
-var baseUrl = 'https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/psl-pk-aifoundryresource/'
+var baseUrl = 'https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/main/'
 
 // ========== Managed Identity ========== //
 module managedIdentityModule 'deploy_managed_identity.bicep' = {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "4835442724575758019"
+      "templateHash": "14571116812938220669"
     }
   },
   "parameters": {
@@ -340,7 +340,7 @@
     "solutionLocation": "[if(empty(parameters('AZURE_LOCATION')), resourceGroup().location, parameters('AZURE_LOCATION'))]",
     "uniqueId": "[toLower(uniqueString(subscription().id, parameters('environmentName'), variables('solutionLocation')))]",
     "solutionPrefix": "[format('km{0}', padLeft(take(variables('uniqueId'), 12), 12, '0'))]",
-    "baseUrl": "https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/psl-pk-aifoundryresource/"
+    "baseUrl": "https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/main/"
   },
   "resources": [
     {


### PR DESCRIPTION
## Purpose
This pull request includes changes to update the `baseUrl` used in deployment scripts and adjusts the `templateHash` in the JSON configuration file. The changes ensure compatibility with the main branch of the repository and reflect updates to the template version.

### Updates to deployment scripts:
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L68-R68): Changed the `baseUrl` to point to the main branch of the repository instead of the previous `psl-pk-aifoundryresource` branch.

### Adjustments to configuration files:
* [`infra/main.json`](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L343-R343): Updated the `baseUrl` to match the new main branch URL, ensuring consistency across deployment configurations.
* [`infra/main.json`](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8): Updated the `templateHash` to reflect changes in the template version.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

