### PR TITLE
fix: fix unittestcases

### DIFF
--- a/src/tests/api/plugins/test_chat_with_data_plugin.py
+++ b/src/tests/api/plugins/test_chat_with_data_plugin.py
@@ -155,11 +155,11 @@ class TestChatWithDataPlugin:
         mock_execute_sql.assert_called_once_with("SELECT * FROM km_processed_data")
 
     @pytest.mark.asyncio
-    @patch("helpers.azure_openai_helper.Config")
+    @patch("plugins.chat_with_data_plugin.Config")
     @patch("plugins.chat_with_data_plugin.execute_sql_query")
     @patch("plugins.chat_with_data_plugin.AIProjectClient")
     @patch("plugins.chat_with_data_plugin.DefaultAzureCredential")
-    async def test_get_SQL_Response_with_ai_project_client(self, mock_azure_credential, mock_ai_project_client, mock_execute_sql, chat_plugin):
+    async def test_get_SQL_Response_with_ai_project_client(self, mock_azure_credential, mock_ai_project_client, mock_execute_sql, mock_config, chat_plugin):
         # Setup AIProjectClient
         chat_plugin.use_ai_project_client = True
         
@@ -167,11 +167,12 @@ class TestChatWithDataPlugin:
         mock_config_instance = MagicMock()
         mock_config_instance.ai_project_endpoint = "https://test-openai.azure.com/"
         mock_config.return_value = mock_config_instance
-        mock_project = MagicMock()
-        mock_ai_project_client = MagicMock()
-        mock_ai_project_client.return_value = mock_project
+        mock_credential_instance = MagicMock()
+        mock_azure_credential.return_value = mock_credential_instance
+        mock_project_instance = MagicMock()
+        mock_ai_project_client.return_value = mock_project_instance
         mock_client = MagicMock()
-        mock_project.inference.get_chat_completions_client.return_value = mock_client
+        mock_project_instance.inference.get_chat_completions_client.return_value = mock_client
         mock_completion = MagicMock()
         mock_completion.choices = [MagicMock()]
         mock_completion.choices[0].message.content = "```sql\nSELECT * FROM km_processed_data\n```"
@@ -184,9 +185,9 @@ class TestChatWithDataPlugin:
         
         # Assertions
         assert result == "Query results data with AI Project Client"
-        mock_client.assert_called_once_with(
-            endpoint="https://test-openai.azure.com/",
-            credential=mock_azure_credential,
+        mock_ai_project_client.assert_called_once_with(
+            endpoint=chat_plugin.ai_project_endpoint,
+            credential=mock_credential_instance
         )
         mock_execute_sql.assert_called_once_with("\nSELECT * FROM km_processed_data\n")
 

--- a/src/tests/api/plugins/test_chat_with_data_plugin.py
+++ b/src/tests/api/plugins/test_chat_with_data_plugin.py
@@ -181,13 +181,18 @@ class TestChatWithDataPlugin:
         mock_execute_sql.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("plugins.chat_with_data_plugin.get_bearer_token_provider")
+    @patch("helpers.azure_openai_helper.Config")
+    @patch("helpers.azure_openai_helper.get_bearer_token_provider")
     @patch("helpers.azure_openai_helper.openai.AzureOpenAI")
-    async def test_get_answers_from_calltranscripts(self, mock_azure_openai, mock_token_provider, chat_plugin):
+    async def test_get_answers_from_calltranscripts(self, mock_azure_openai, mock_token_provider, mock_config, chat_plugin):
         # Setup mock
         mock_token_provider.return_value = lambda: "fake_token"
         mock_client = MagicMock()
         mock_azure_openai.return_value = mock_client
+        mock_config_instance = MagicMock()
+        mock_config_instance.azure_openai_endpoint = "https://test-openai.azure.com/"
+        mock_config_instance.azure_openai_api_version = "2024-02-15-preview"
+        mock_config.return_value = mock_config_instance
         mock_completion = MagicMock()
         mock_completion.choices = [MagicMock()]
         mock_completion.choices[0].message = MagicMock()

--- a/src/tests/api/services/test_chat_service.py
+++ b/src/tests/api/services/test_chat_service.py
@@ -9,7 +9,7 @@ from semantic_kernel.exceptions.agent_exceptions import AgentException as RealAg
 
 
 # ---- Patch imports before importing the service under test ----
-@patch("common.config.config.Config")
+@patch("helpers.azure_openai_helper.Config")
 @patch("semantic_kernel.agents.AzureAIAgentThread")
 @patch("azure.ai.agents.models.TruncationObject")
 @patch("semantic_kernel.exceptions.agent_exceptions.AgentException")
@@ -167,8 +167,6 @@ class TestChatService:
         
         service = ChatService(mock_request)
         
-        assert service.azure_openai_endpoint == "https://test.openai.azure.com"
-        assert service.azure_openai_api_version == "2024-02-15-preview"
         assert service.azure_openai_deployment_name == "gpt-4o-mini"
         assert service.agent == mock_request.app.state.agent
         assert ChatService.thread_cache is not None

--- a/src/tests/api/services/test_history_service.py
+++ b/src/tests/api/services/test_history_service.py
@@ -28,7 +28,7 @@ def history_service(mock_config_instance):
         # Create patches for other dependencies used by HistoryService
         with patch("services.history_service.CosmosConversationClient"):
             with patch("services.history_service.AsyncAzureOpenAI"):
-                with patch("services.history_service.get_bearer_token_provider"):
+                with patch("helpers.azure_openai_helper.get_bearer_token_provider"):
                     with patch("services.history_service.complete_chat_request"):
                         service = HistoryService()
                         return service
@@ -105,7 +105,7 @@ class TestHistoryService:
 
     def test_init_openai_client_no_api_key(self, history_service):
         """Test OpenAI client initialization with no API key"""
-        with patch("services.history_service.get_bearer_token_provider", return_value="token_provider"):
+        with patch("helpers.azure_openai_helper.get_bearer_token_provider", return_value="token_provider"):
             with patch("services.history_service.AsyncAzureOpenAI", return_value="openai_client"):
                 client = history_service.init_openai_client()
                 assert client == "openai_client"


### PR DESCRIPTION
## Purpose
This pull request refactors test cases across multiple files to replace direct imports of `Config` and `get_bearer_token_provider` with their counterparts in `helpers.azure_openai_helper`. Additionally, it introduces mock configuration instances to simulate Azure OpenAI settings in tests, ensuring consistency and modularity in the test setup.

### Refactoring for `helpers.azure_openai_helper`:

* [`src/tests/api/plugins/test_chat_with_data_plugin.py`](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2L28-R40): Replaced imports of `Config` and `get_bearer_token_provider` with `helpers.azure_openai_helper.Config` and `helpers.azure_openai_helper.get_bearer_token_provider` across multiple test cases. Mock configuration instances were introduced to simulate Azure OpenAI endpoint and API version settings. [[1]](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2L28-R40) [[2]](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2R68-R100) [[3]](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2L109-R133) [[4]](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2R158-R175) [[5]](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2L163-R191) [[6]](diffhunk://#diff-704d83d8eb40fb5a0d85ecaee5d58e9f10d32c4ba550b1791732e2c566d44aa2L184-R222)

* [`src/tests/api/services/test_chat_service.py`](diffhunk://#diff-9a09f47021f5273f65c402e81017e3d4ab9d1b13eae15498ebbbeb79d9286269L12-R12): Updated the import of `Config` to use `helpers.azure_openai_helper.Config` for consistency. Removed assertions for endpoint and API version in `test_init` as these are now handled via mock configuration. [[1]](diffhunk://#diff-9a09f47021f5273f65c402e81017e3d4ab9d1b13eae15498ebbbeb79d9286269L12-R12) [[2]](diffhunk://#diff-9a09f47021f5273f65c402e81017e3d4ab9d1b13eae15498ebbbeb79d9286269L170-L171)

* [`src/tests/api/services/test_history_service.py`](diffhunk://#diff-30a22692de2f5946312b13379163d2452820a09506cf3ea176c47c23bd60864eL31-R31): Updated imports of `get_bearer_token_provider` to use `helpers.azure_openai_helper.get_bearer_token_provider` in the `history_service` and `test_init_openai_client_no_deployment_name` methods. [[1]](diffhunk://#diff-30a22692de2f5946312b13379163d2452820a09506cf3ea176c47c23bd60864eL31-R31) [[2]](diffhunk://#diff-30a22692de2f5946312b13379163d2452820a09506cf3ea176c47c23bd60864eL108-R108)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

