### PR TITLE
ci: update test-automation workflow to remove cron schedule 

### DIFF
--- a/.github/workflows/test-automation.yml
+++ b/.github/workflows/test-automation.yml
@@ -7,9 +7,7 @@ on:
       - dev
     paths:
       - 'tests/e2e-test/**'
-  schedule:
 
-    - cron: '0 13 * * *'  # Runs at 1 PM UTC
   workflow_dispatch:
   # NEW: Add workflow_call to make it reusable
   workflow_call:


### PR DESCRIPTION
## Purpose
This pull request updates the `.github/workflows/test-automation.yml` file to improve the workflow configuration by removing the scheduled cron job and adding support for reusable workflows.

Workflow configuration updates:

* [`.github/workflows/test-automation.yml`](diffhunk://#diff-a510ee846ff45a595b5e1076964599828375ac8bf5165fb98f550a1e3a03e0a0L10-L12): Removed the `schedule` section, which previously included a cron job to run at 1 PM UTC, and added the `workflow_call` trigger to make the workflow reusable.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

