### PR TITLE
fix: Can't use custom image tag with USE_LOCAL_BUILD=true

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -12,13 +12,13 @@ hooks:
   preprovision:
     windows:
       run: |
-        $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"; $logFile = "azd_preprovision_$timestamp.log"; ./infra/scripts/docker-build.ps1 $env:AZURE_SUBSCRIPTION_ID $env:AZURE_ENV_NAME $env:AZURE_LOCATION $env:AZURE_RESOURCE_GROUP $env:USE_LOCAL_BUILD *>&1 | Tee-Object -FilePath $logFile
+        $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"; $logFile = "azd_preprovision_$timestamp.log"; ./infra/scripts/docker-build.ps1 $env:AZURE_SUBSCRIPTION_ID $env:AZURE_ENV_NAME $env:AZURE_LOCATION $env:AZURE_RESOURCE_GROUP $env:USE_LOCAL_BUILD $env:AZURE_ENV_IMAGETAG *>&1 | Tee-Object -FilePath $logFile
       shell: pwsh
       continueOnError: false
       interactive: true
     posix:
       run: |
-        timestamp=$(date +"%Y%m%d-%H%M%S"); logFile="azd_preprovision_$timestamp.log"; sed -i 's/\r$//' ./infra/scripts/docker-build.sh; ./infra/scripts/docker-build.sh "$AZURE_SUBSCRIPTION_ID" "$AZURE_ENV_NAME" "$AZURE_LOCATION" "$AZURE_RESOURCE_GROUP" "$USE_LOCAL_BUILD" 2>&1 | tee "$logFile"
+        timestamp=$(date +"%Y%m%d-%H%M%S"); logFile="azd_preprovision_$timestamp.log"; sed -i 's/\r$//' ./infra/scripts/docker-build.sh; ./infra/scripts/docker-build.sh "$AZURE_SUBSCRIPTION_ID" "$AZURE_ENV_NAME" "$AZURE_LOCATION" "$AZURE_RESOURCE_GROUP" "$USE_LOCAL_BUILD" "$AZURE_ENV_IMAGETAG" 2>&1 | tee "$logFile"
       shell: sh
       continueOnError: false
       interactive: true

--- a/infra/scripts/docker-build.ps1
+++ b/infra/scripts/docker-build.ps1
@@ -4,15 +4,20 @@ param (
     [string]$ENV_NAME,
     [string]$AZURE_LOCATION,
     [string]$AZURE_RESOURCE_GROUP,
-    [string]$USE_LOCAL_BUILD
+    [string]$USE_LOCAL_BUILD,
+    [string]$AZURE_ENV_IMAGETAG
 )
 
 # Convert USE_LOCAL_BUILD to Boolean
 $USE_LOCAL_BUILD = if ($USE_LOCAL_BUILD -match "^(?i:true)$") { $true } else { $false }
 
+if ([string]::IsNullOrEmpty($AZURE_ENV_IMAGETAG)) {
+    $AZURE_ENV_IMAGETAG = "latest"
+}
+
 # Validate required parameters
 if (-not $AZURE_SUBSCRIPTION_ID -or -not $ENV_NAME -or -not $AZURE_LOCATION -or -not $AZURE_RESOURCE_GROUP) {
-    Write-Error "Missing required arguments. Usage: docker-build.ps1 <AZURE_SUBSCRIPTION_ID> <ENV_NAME> <AZURE_LOCATION> <AZURE_RESOURCE_GROUP> <USE_LOCAL_BUILD>"
+    Write-Error "Missing required arguments. Usage: docker-build.ps1 <AZURE_SUBSCRIPTION_ID> <ENV_NAME> <AZURE_LOCATION> <AZURE_RESOURCE_GROUP> <USE_LOCAL_BUILD> <AZURE_ENV_IMAGETAG>"
     exit 1
 }
 
@@ -102,8 +107,7 @@ function Build-And-Push-Image {
 }
 
 # STEP 8: Build and push images with provided tag
-$ACR_IMAGE_TAG = "latest"
-Build-And-Push-Image "km-api" $ApiAppDockerfilePath $ApiAppContextPath $ACR_IMAGE_TAG
-Build-And-Push-Image "km-app" $WebAppDockerfilePath $WebAppContextPath $ACR_IMAGE_TAG
+Build-And-Push-Image "km-api" $ApiAppDockerfilePath $ApiAppContextPath $AZURE_ENV_IMAGETAG
+Build-And-Push-Image "km-app" $WebAppDockerfilePath $WebAppContextPath $AZURE_ENV_IMAGETAG
 
-Write-Host "`nAll Docker images built and pushed successfully with tag: $ACR_IMAGE_TAG"
+Write-Host "`nAll Docker images built and pushed successfully with tag: $AZURE_ENV_IMAGETAG"

--- a/infra/scripts/docker-build.sh
+++ b/infra/scripts/docker-build.sh
@@ -7,10 +7,11 @@ ENV_NAME="$2"
 AZURE_LOCATION="$3"
 AZURE_RESOURCE_GROUP="$4"
 USE_LOCAL_BUILD="$5"
+AZURE_ENV_IMAGETAG="$6"
 
 # Validate required parameters
 if [[ -z "$AZURE_SUBSCRIPTION_ID" || -z "$ENV_NAME" || -z "$AZURE_LOCATION" || -z "$AZURE_RESOURCE_GROUP" ]]; then
-    echo "Missing required arguments. Usage: docker-build.sh <AZURE_SUBSCRIPTION_ID> <ENV_NAME> <AZURE_LOCATION> <AZURE_RESOURCE_GROUP> <USE_LOCAL_BUILD>"
+    echo "Missing required arguments. Usage: docker-build.sh <AZURE_SUBSCRIPTION_ID> <ENV_NAME> <AZURE_LOCATION> <AZURE_RESOURCE_GROUP> <USE_LOCAL_BUILD> <AZURE_ENV_IMAGETAG>"
     exit 1
 fi
 
@@ -22,6 +23,8 @@ if [[ "${USE_LOCAL_BUILD,,}" != "true" ]]; then
     echo "Local Build not enabled. Using prebuilt image."
     exit 0
 fi
+
+AZURE_ENV_IMAGETAG=${AZURE_ENV_IMAGETAG:-latest}
 
 echo "Local Build enabled. Starting build process."
 
@@ -101,8 +104,7 @@ build_and_push_image() {
 }
 
 # STEP 8: Build and push images with provided tag
-ACR_IMAGE_TAG="latest"
-build_and_push_image "km-api" "$APIAPP_DOCKERFILE_PATH" "$APIAPP_CONTEXT_PATH" "$ACR_IMAGE_TAG"
-build_and_push_image "km-app" "$WEBAPP_DOCKERFILE_PATH" "$WEBAPP_CONTEXT_PATH" "$ACR_IMAGE_TAG"
+build_and_push_image "km-api" "$APIAPP_DOCKERFILE_PATH" "$APIAPP_CONTEXT_PATH" "$AZURE_ENV_IMAGETAG"
+build_and_push_image "km-app" "$WEBAPP_DOCKERFILE_PATH" "$WEBAPP_CONTEXT_PATH" "$AZURE_ENV_IMAGETAG"
 
-echo -e "\nAll Docker images built and pushed successfully with tag: $ACR_IMAGE_TAG"
+echo -e "\nAll Docker images built and pushed successfully with tag: $AZURE_ENV_IMAGETAG"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces support for specifying a custom image tag (`AZURE_ENV_IMAGETAG`) during the Docker build and push process. The changes ensure that this new parameter is optional, defaulting to `latest` if not provided, and propagate it through the relevant scripts and configuration files.

### Enhancements to Docker Build Process:

* **Added `AZURE_ENV_IMAGETAG` Parameter**:
  - Updated `infra/scripts/docker-build.ps1` and `infra/scripts/docker-build.sh` to accept an additional parameter, `AZURE_ENV_IMAGETAG`, for specifying a custom Docker image tag. This parameter defaults to `latest` if not provided. [[1]](diffhunk://#diff-bbd8ac6fc2f33cfdb70dd2aad3a606da6e0dae8518301f42797c548c040a9939L7-R20) [[2]](diffhunk://#diff-56125c9f69919272261971d188ab641a2ccaa992f4bd2750e78f66ba3aac1577R10-R14) [[3]](diffhunk://#diff-56125c9f69919272261971d188ab641a2ccaa992f4bd2750e78f66ba3aac1577R27-R28)
  - Updated usage instructions in both scripts to reflect the new parameter. [[1]](diffhunk://#diff-bbd8ac6fc2f33cfdb70dd2aad3a606da6e0dae8518301f42797c548c040a9939L7-R20) [[2]](diffhunk://#diff-56125c9f69919272261971d188ab641a2ccaa992f4bd2750e78f66ba3aac1577R10-R14)

* **Modified Image Tagging Logic**:
  - Replaced the hardcoded `latest` tag with the value of `AZURE_ENV_IMAGETAG` when building and pushing Docker images in both scripts. [[1]](diffhunk://#diff-bbd8ac6fc2f33cfdb70dd2aad3a606da6e0dae8518301f42797c548c040a9939L105-R113) [[2]](diffhunk://#diff-56125c9f69919272261971d188ab641a2ccaa992f4bd2750e78f66ba3aac1577L104-R110)

### Updates to Azure Configuration:

* **Propagated `AZURE_ENV_IMAGETAG` in Preprovision Hooks**:
  - Updated the `preprovision` hooks in `azure.yaml` to pass the `AZURE_ENV_IMAGETAG` parameter to the Docker build scripts for both Windows and POSIX environments.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

