### PR TITLE
fix: remove conditional logic for assigning the `assignAiUserRoleToAiProject` module

### DIFF
--- a/infra/deploy_backend_docker.bicep
+++ b/infra/deploy_backend_docker.bicep
@@ -147,7 +147,7 @@ resource aiUser 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = 
   name: '53ca6127-db72-4b80-b1b0-d745d6d5456d'
 }
 
-module assignAiUserRoleToAiProject 'deploy_foundry_role_assignment.bicep' = if (!empty(azureExistingAIProjectResourceId)){
+module assignAiUserRoleToAiProject 'deploy_foundry_role_assignment.bicep' = {
   name: 'assignAiUserRoleToAiProject'
   scope: resourceGroup(existingAIServiceSubscription, existingAIServiceResourceGroup)
   params: {


### PR DESCRIPTION
## Purpose
This pull request includes a small change to the `infra/deploy_backend_docker.bicep` file. The conditional logic for assigning the `assignAiUserRoleToAiProject` module has been removed, making the module definition unconditional.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.