### PR TITLE
fix: removes the use of the `AZURE-OPENAI-CU-KEY` secret across the infrastructure and scripts

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -300,14 +300,6 @@ resource azureOpenAICUEndpointEntry 'Microsoft.KeyVault/vaults/secrets@2021-11-0
   }
 }
 
-resource azureOpenAICUApiKeyEntry 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
-  parent: keyVault
-  name: 'AZURE-OPENAI-CU-KEY'
-  properties: {
-    value: aiServices_CU.listKeys().key1
-  }
-}
-
 resource azureOpenAICUApiVersionEntry 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
   parent: keyVault
   name: 'AZURE-OPENAI-CU-VERSION'

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "14769206549361904379"
+      "templateHash": "14797468639789152416"
     }
   },
   "parameters": {
@@ -652,7 +652,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "1294065809838303541"
+              "templateHash": "1288056001550775266"
             }
           },
           "parameters": {
@@ -1208,17 +1208,6 @@
               "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AZURE-OPENAI-CU-ENDPOINT')]",
               "properties": {
                 "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu')), '2025-04-01-preview').endpoints['OpenAI Language Model Instance API']]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.KeyVault/vaults/secrets",
-              "apiVersion": "2021-11-01-preview",
-              "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AZURE-OPENAI-CU-KEY')]",
-              "properties": {
-                "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu')), '2025-04-01-preview').key1]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName_cu'))]"
@@ -2521,7 +2510,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "12601944025413037469"
+              "templateHash": "2610739623677529550"
             }
           },
           "parameters": {
@@ -2827,7 +2816,6 @@
               }
             },
             {
-              "condition": "[not(empty(parameters('azureExistingAIProjectResourceId')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "assignAiUserRoleToAiProject",

--- a/infra/scripts/index_scripts/02_create_cu_template_audio.py
+++ b/infra/scripts/index_scripts/02_create_cu_template_audio.py
@@ -28,7 +28,6 @@ parent_dir = Path(Path.cwd()).parent
 sys.path.append(str(parent_dir))
 from content_understanding_client import AzureContentUnderstandingClient
 AZURE_AI_ENDPOINT = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-ENDPOINT")
-AZURE_OPENAI_CU_KEY = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-KEY")
 AZURE_AI_API_VERSION = "2024-12-01-preview" 
 
 
@@ -37,7 +36,6 @@ token_provider = get_bearer_token_provider(credential, "https://cognitiveservice
 client = AzureContentUnderstandingClient(
     endpoint=AZURE_AI_ENDPOINT,
     api_version=AZURE_AI_API_VERSION,
-    subscription_key=AZURE_OPENAI_CU_KEY,
     token_provider=token_provider
 )
 

--- a/infra/scripts/index_scripts/02_create_cu_template_text.py
+++ b/infra/scripts/index_scripts/02_create_cu_template_text.py
@@ -28,7 +28,6 @@ parent_dir = Path(Path.cwd()).parent
 sys.path.append(str(parent_dir))
 from content_understanding_client import AzureContentUnderstandingClient
 AZURE_AI_ENDPOINT = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-ENDPOINT")
-AZURE_OPENAI_CU_KEY = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-KEY")
 AZURE_AI_API_VERSION = "2024-12-01-preview" 
 
 
@@ -38,7 +37,6 @@ token_provider = get_bearer_token_provider(credential, "https://cognitiveservice
 client = AzureContentUnderstandingClient(
     endpoint=AZURE_AI_ENDPOINT,
     api_version=AZURE_AI_API_VERSION,
-    subscription_key=AZURE_OPENAI_CU_KEY,
     token_provider=token_provider
 )
 

--- a/infra/scripts/index_scripts/03_cu_process_data_text.py
+++ b/infra/scripts/index_scripts/03_cu_process_data_text.py
@@ -182,7 +182,6 @@ conn.commit()
 
 
 AZURE_AI_ENDPOINT = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-ENDPOINT")
-AZURE_OPENAI_CU_KEY = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-KEY")
 AZURE_AI_API_VERSION = "2024-12-01-preview" 
 
 credential = DefaultAzureCredential(managed_identity_client_id=managed_identity_client_id)
@@ -191,7 +190,6 @@ token_provider = get_bearer_token_provider(credential, "https://cognitiveservice
 client = AzureContentUnderstandingClient(
     endpoint=AZURE_AI_ENDPOINT,
     api_version=AZURE_AI_API_VERSION,
-    subscription_key=AZURE_OPENAI_CU_KEY,
     token_provider=token_provider
     )
 

--- a/infra/scripts/index_scripts/04_cu_process_data_new_data.py
+++ b/infra/scripts/index_scripts/04_cu_process_data_new_data.py
@@ -256,7 +256,6 @@ conn.commit()
 
 
 AZURE_AI_ENDPOINT = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-ENDPOINT")
-AZURE_OPENAI_CU_KEY = get_secrets_from_kv(key_vault_name,"AZURE-OPENAI-CU-KEY")
 AZURE_AI_API_VERSION = "2024-12-01-preview" 
 
 credential = DefaultAzureCredential()
@@ -265,7 +264,6 @@ token_provider = get_bearer_token_provider(credential, "https://cognitiveservice
 client = AzureContentUnderstandingClient(
     endpoint=AZURE_AI_ENDPOINT,
     api_version=AZURE_AI_API_VERSION,
-    subscription_key=AZURE_OPENAI_CU_KEY,
     token_provider=token_provider
     )
 


### PR DESCRIPTION
## Purpose
This pull request removes the use of the `AZURE-OPENAI-CU-KEY` secret across the infrastructure and scripts, simplifying the configuration and authentication process. The changes primarily involve the removal of references to this key in both the infrastructure deployment files and Python scripts.

### Infrastructure Changes:
* Removed the `azureOpenAICUApiKeyEntry` resource from `infra/deploy_ai_foundry.bicep`, which previously stored the `AZURE-OPENAI-CU-KEY` secret in Azure Key Vault.
* Deleted the corresponding `AZURE-OPENAI-CU-KEY` secret configuration in `infra/main.json`, including its dependencies and references.
* Updated template hash values in `infra/main.json` to reflect changes in the Bicep and JSON templates. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L655-R655) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2524-R2513)

### Script Changes:
* Removed the retrieval and usage of the `AZURE-OPENAI-CU-KEY` secret in the following scripts:
  - `02_create_cu_template_audio.py` [[1]](diffhunk://#diff-9d1f7b1c08f9d3a58e951dd21f5ea2d442a11d28f8ad5c830a261974fe0fc7b5L31) [[2]](diffhunk://#diff-9d1f7b1c08f9d3a58e951dd21f5ea2d442a11d28f8ad5c830a261974fe0fc7b5L40)
  - `02_create_cu_template_text.py` [[1]](diffhunk://#diff-f6c8c9a543fda9b4256a35fea8921a552a36977f80d32fd22c504f2bccdb5016L31) [[2]](diffhunk://#diff-f6c8c9a543fda9b4256a35fea8921a552a36977f80d32fd22c504f2bccdb5016L41)
  - `03_cu_process_data_text.py` [[1]](diffhunk://#diff-8d35b633760eb49ed50a65d41092cf6eb6b64ae569d388d1d80a5e27e74e324aL185) [[2]](diffhunk://#diff-8d35b633760eb49ed50a65d41092cf6eb6b64ae569d388d1d80a5e27e74e324aL194)
  - `04_cu_process_data_new_data.py` [[1]](diffhunk://#diff-a085e52601194ec90694d801dcb0410557f0de0333208790fabf2cd6e0b61229L259) [[2]](diffhunk://#diff-a085e52601194ec90694d801dcb0410557f0de0333208790fabf2cd6e0b61229L268)

These changes streamline the handling of secrets and reduce reliance on the `AZURE-OPENAI-CU-KEY`, likely in favor of other authentication mechanisms like token-based authentication.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
