### PR TITLE
fix: Update docker-build.yml to use latest_fdp tag image for FDP changes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,7 +49,7 @@ jobs:
         id: determine_tag
         run: |
          if [[ "${{ github.ref_name }}" == "main" ]]; then
-          echo "tagname=latest" >> $GITHUB_OUTPUT
+          echo "tagname=latest_fdp" >> $GITHUB_OUTPUT
          elif [[ "${{ github.ref_name }}" == "dev" ]]; then
           echo "tagname=dev" >> $GITHUB_OUTPUT
          elif [[ "${{ github.ref_name }}" == "demo" ]]; then


### PR DESCRIPTION
## Purpose
This pull request modifies the Docker build workflow to adjust the tagging convention for the `main` branch. 

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L52-R52): Updated the `determine_tag` step to change the tag name for the `main` branch from `latest` to `latest_fdp`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No
