### PR TITLE
refactor: removing the UseLocalBuild flag and updated scripts to run local docker build manually post deployment

### DIFF
--- a/.github/workflows/test-automation.yml
+++ b/.github/workflows/test-automation.yml
@@ -1,15 +1,6 @@
 name: Test Automation KMGeneric
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-    paths:
-      - 'tests/e2e-test/**'
-
-  workflow_dispatch:
-  # NEW: Add workflow_call to make it reusable
   workflow_call:
     inputs:
       KMGENERIC_URL:

--- a/documents/CustomizingAzdParameters.md
+++ b/documents/CustomizingAzdParameters.md
@@ -22,7 +22,6 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_ENV_IMAGETAG`                      | string  | `latest`        | Sets the image tag (`latest`, `dev`, `hotfix`, etc.).   |
 | `AZURE_OPENAI_EMBEDDING_MODEL_CAPACITY`   | integer | `80`                     | Sets the capacity for the embedding model deployment.                      |
 | `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID`    | string  | Guide to get your [Existing Workspace ID](/documents/re-use-log-analytics.md)            | Reuses an existing Log Analytics Workspace instead of creating a new one.  |
-| `USE_LOCAL_BUILD`    | string  | `false`           | Indicates whether to use a local container build for deployment.  |
 | `AZURE_EXISTING_AI_PROJECT_RESOURCE_ID`    | string  | `<Existing AI Project resource Id>`            | Reuses an existing AIFoundry and AIFoundryProject instead of creating a new one.  |
 
 

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -120,7 +120,6 @@ When you start the deployment, most parameters will have **default values**, but
 | **Embedding Model Capacity**                | Set the capacity for **embedding models** (in thousands).                                                 | 80k                    |
 | **Image Tag**                               | Docker image tag to deploy. Common values: `latest`, `dev`, `hotfix`.                  | latest       |
 | **Existing Log Analytics Workspace**        | To reuse an existing Log Analytics Workspace ID.                                                          | *(empty)*              |
-| **Use Local Build**                         | Boolean flag to determine if local container builds should be used.                         | false             |
 
 
 
@@ -186,6 +185,24 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
 2. **Deleting Resources After a Failed Deployment**  
 
      - Follow steps in [Delete Resource Group](./DeleteResourceGroup.md) if your deployment fails and/or you need to clean up the resources.
+
+3. **Optional: Publishing Local Build Container to Azure Container Registry**
+
+   If you need to rebuild the source code and push the updated container to the deployed Azure Container Registry, follow these steps:
+
+   - **Linux/macOS**:
+     ```bash
+     cd ./infra/scripts/
+     ./docker-build.sh
+     ```
+
+   - **Windows (PowerShell)**:
+     ```powershell
+     cd .\infra\scripts\
+     .\docker-build.ps1
+     ```
+
+    This will create a new Azure Container Registry, rebuild the source code, package it into a container, and push it to the Container Registry created.
 
 ## Sample Questions
 

--- a/infra/deploy_app_service.bicep
+++ b/infra/deploy_app_service.bicep
@@ -12,7 +12,6 @@ param appSettings object = {}
 param appServicePlanId string
 param appImageName string
 param userassignedIdentityId string = ''
-// param useLocalBuild string
 
 resource appService 'Microsoft.Web/sites@2020-06-01' = {
   name: solutionName
@@ -28,7 +27,6 @@ resource appService 'Microsoft.Web/sites@2020-06-01' = {
   properties: {
     serverFarmId: appServicePlanId
     siteConfig: {
-      // acrUseManagedIdentityCreds: useLocalBuild == 'true'
       alwaysOn: true
       ftpsState: 'Disabled'
       linuxFxVersion: appImageName

--- a/infra/deploy_app_service.bicep
+++ b/infra/deploy_app_service.bicep
@@ -12,7 +12,7 @@ param appSettings object = {}
 param appServicePlanId string
 param appImageName string
 param userassignedIdentityId string = ''
-param useLocalBuild string
+// param useLocalBuild string
 
 resource appService 'Microsoft.Web/sites@2020-06-01' = {
   name: solutionName
@@ -28,7 +28,7 @@ resource appService 'Microsoft.Web/sites@2020-06-01' = {
   properties: {
     serverFarmId: appServicePlanId
     siteConfig: {
-      acrUseManagedIdentityCreds: useLocalBuild == 'true'
+      // acrUseManagedIdentityCreds: useLocalBuild == 'true'
       alwaysOn: true
       ftpsState: 'Disabled'
       linuxFxVersion: appImageName

--- a/infra/deploy_backend_docker.bicep
+++ b/infra/deploy_backend_docker.bicep
@@ -11,7 +11,7 @@ param appServicePlanId string
 param userassignedIdentityId string
 param keyVaultName string
 param aiServicesName string
-param useLocalBuild string
+// param useLocalBuild string
 param azureExistingAIProjectResourceId string = ''
 param aiSearchName string
 var existingAIServiceSubscription = !empty(azureExistingAIProjectResourceId) ? split(azureExistingAIProjectResourceId, '/')[2] : subscription().subscriptionId
@@ -92,7 +92,7 @@ module appService 'deploy_app_service.bicep' = {
     appServicePlanId: appServicePlanId
     appImageName: imageName
     userassignedIdentityId:userassignedIdentityId
-    useLocalBuild: useLocalBuild
+    // useLocalBuild: useLocalBuild
     appSettings: union(
       appSettings,
       {
@@ -176,23 +176,25 @@ module assignAiUserRoleToAiProject 'deploy_foundry_role_assignment.bicep' = {
   }
 }
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = if (useLocalBuild == 'true') {
-  name: acrName
-}
+// resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = if (useLocalBuild == 'true') {
+//   name: acrName
+// }
 
-resource AcrPull 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = if (useLocalBuild == 'true') {
-  name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
-}
+// resource AcrPull 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = if (useLocalBuild == 'true') {
+//   name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+// }
 
-resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (useLocalBuild == 'true') {
-  name: guid(appService.name, AcrPull.id)
-  scope: containerRegistry
-  properties: {
-    roleDefinitionId: AcrPull.id
-    principalId: appService.outputs.identityPrincipalId
-  }
-}
+// resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (useLocalBuild == 'true') {
+//   name: guid(appService.name, AcrPull.id)
+//   scope: containerRegistry
+//   properties: {
+//     roleDefinitionId: AcrPull.id
+//     principalId: appService.outputs.identityPrincipalId
+//   }
+// }
 
 output appUrl string = appService.outputs.appUrl
 output reactAppLayoutConfig string = reactAppLayoutConfig
 output appInsightInstrumentationKey string = reference(applicationInsightsId, '2015-05-01').InstrumentationKey
+output backendManagedIdentityPrincipalId string = appService.outputs.identityPrincipalId
+output backendAppName string = name

--- a/infra/deploy_backend_docker.bicep
+++ b/infra/deploy_backend_docker.bicep
@@ -11,7 +11,6 @@ param appServicePlanId string
 param userassignedIdentityId string
 param keyVaultName string
 param aiServicesName string
-// param useLocalBuild string
 param azureExistingAIProjectResourceId string = ''
 param aiSearchName string
 var existingAIServiceSubscription = !empty(azureExistingAIProjectResourceId) ? split(azureExistingAIProjectResourceId, '/')[2] : subscription().subscriptionId
@@ -92,7 +91,6 @@ module appService 'deploy_app_service.bicep' = {
     appServicePlanId: appServicePlanId
     appImageName: imageName
     userassignedIdentityId:userassignedIdentityId
-    // useLocalBuild: useLocalBuild
     appSettings: union(
       appSettings,
       {
@@ -176,22 +174,6 @@ module assignAiUserRoleToAiProject 'deploy_foundry_role_assignment.bicep' = {
   }
 }
 
-// resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = if (useLocalBuild == 'true') {
-//   name: acrName
-// }
-
-// resource AcrPull 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = if (useLocalBuild == 'true') {
-//   name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
-// }
-
-// resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (useLocalBuild == 'true') {
-//   name: guid(appService.name, AcrPull.id)
-//   scope: containerRegistry
-//   properties: {
-//     roleDefinitionId: AcrPull.id
-//     principalId: appService.outputs.identityPrincipalId
-//   }
-// }
 
 output appUrl string = appService.outputs.appUrl
 output reactAppLayoutConfig string = reactAppLayoutConfig

--- a/infra/deploy_container_registry.bicep
+++ b/infra/deploy_container_registry.bicep
@@ -8,12 +8,18 @@ var solutionName = 'km${padLeft(take(uniqueId, 12), 12, '0')}'
 var abbrs = loadJsonContent('./abbreviations.json')
 var containerRegistryName = '${abbrs.containers.containerRegistry}${solutionName}'
 var containerRegistryNameCleaned = replace(containerRegistryName, '-', '')
+
+@description('List of Principal Ids to which ACR pull role assignment is required')
+param acrPullPrincipalIds array = []
+
+@description('Provide a tier of your Azure Container Registry.')
+param acrSku string = 'Premium'
  
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' = {
   name: containerRegistryName
   location: solutionLocation
   sku: {
-    name: 'Premium'
+    name: acrSku
   }
   properties: {
     dataEndpointEnabled: false
@@ -38,6 +44,19 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' =
     zoneRedundancy: 'Disabled'
   }
 }
+
+// Add Role assignments for required principal id's
+resource acrPullRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in acrPullPrincipalIds: {
+  name: guid(principalId, 'acrpull')
+  scope: containerRegistry
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+    )
+    principalId: principalId
+  }
+}]
  
 output createdAcrName string = containerRegistryNameCleaned
 output createdAcrId string = containerRegistry.id

--- a/infra/deploy_frontend_docker.bicep
+++ b/infra/deploy_frontend_docker.bicep
@@ -8,7 +8,7 @@ param solutionLocation string
 @secure()
 param appSettings object = {}
 param appServicePlanId string
-param useLocalBuild string
+// param useLocalBuild string
 
 var imageName = 'DOCKER|${acrName}.azurecr.io/km-app:${imageTag}'
 //var name = '${solutionName}-app'
@@ -20,7 +20,7 @@ module appService 'deploy_app_service.bicep' = {
     solutionName: name
     appServicePlanId: appServicePlanId
     appImageName: imageName
-    useLocalBuild: useLocalBuild
+    // useLocalBuild: useLocalBuild
     appSettings: union(
       appSettings,
       {
@@ -30,21 +30,23 @@ module appService 'deploy_app_service.bicep' = {
   }
 }
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = if (useLocalBuild == 'true') {
-  name: acrName
-}
+// resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = if (useLocalBuild == 'true') {
+//   name: acrName
+// }
 
-resource AcrPull 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = if (useLocalBuild == 'true') {
-  name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
-}
+// resource AcrPull 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = if (useLocalBuild == 'true') {
+//   name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+// }
 
-resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (useLocalBuild == 'true') {
-  name: guid(appService.name, AcrPull.id)
-  scope: containerRegistry
-  properties: {
-    roleDefinitionId: AcrPull.id
-    principalId: appService.outputs.identityPrincipalId
-  }
-}
+// resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (useLocalBuild == 'true') {
+//   name: guid(appService.name, AcrPull.id)
+//   scope: containerRegistry
+//   properties: {
+//     roleDefinitionId: AcrPull.id
+//     principalId: appService.outputs.identityPrincipalId
+//   }
+// }
 
 output appUrl string = appService.outputs.appUrl
+output frontendManagedIdentityPrincipalId string = appService.outputs.identityPrincipalId
+output frontendAppName string = name

--- a/infra/deploy_frontend_docker.bicep
+++ b/infra/deploy_frontend_docker.bicep
@@ -8,7 +8,6 @@ param solutionLocation string
 @secure()
 param appSettings object = {}
 param appServicePlanId string
-// param useLocalBuild string
 
 var imageName = 'DOCKER|${acrName}.azurecr.io/km-app:${imageTag}'
 //var name = '${solutionName}-app'
@@ -20,7 +19,6 @@ module appService 'deploy_app_service.bicep' = {
     solutionName: name
     appServicePlanId: appServicePlanId
     appImageName: imageName
-    // useLocalBuild: useLocalBuild
     appSettings: union(
       appSettings,
       {
@@ -30,22 +28,6 @@ module appService 'deploy_app_service.bicep' = {
   }
 }
 
-// resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = if (useLocalBuild == 'true') {
-//   name: acrName
-// }
-
-// resource AcrPull 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = if (useLocalBuild == 'true') {
-//   name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
-// }
-
-// resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (useLocalBuild == 'true') {
-//   name: guid(appService.name, AcrPull.id)
-//   scope: containerRegistry
-//   properties: {
-//     roleDefinitionId: AcrPull.id
-//     principalId: appService.outputs.identityPrincipalId
-//   }
-// }
 
 output appUrl string = appService.outputs.appUrl
 output frontendManagedIdentityPrincipalId string = appService.outputs.identityPrincipalId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -66,11 +66,11 @@ param imageTag string = 'latest_fdp'
 param AZURE_LOCATION string=''
 var solutionLocation = empty(AZURE_LOCATION) ? resourceGroup().location : AZURE_LOCATION
 
-@description('Set this flag to true only if you are deploying from Local')
-param useLocalBuild string = 'false'
+// @description('Set this flag to true only if you are deploying from Local')
+// param useLocalBuild string = 'false'
 
-// Convert input to lowercase
-var useLocalBuildLower = toLower(useLocalBuild)
+// // Convert input to lowercase
+// var useLocalBuildLower = toLower(useLocalBuild)
 
 var uniqueId = toLower(uniqueString(subscription().id, environmentName, solutionLocation))
 
@@ -89,9 +89,9 @@ param aiDeploymentsLocation string
 
 var solutionPrefix = 'km${padLeft(take(uniqueId, 12), 12, '0')}'
 
-var containerRegistryName = '${abbrs.containers.containerRegistry}${solutionPrefix}'
-var containerRegistryNameCleaned = replace(containerRegistryName, '-', '')
-var acrName = useLocalBuildLower == 'true' ? containerRegistryNameCleaned : 'kmcontainerreg'
+// var containerRegistryName = '${abbrs.containers.containerRegistry}${solutionPrefix}'
+// var containerRegistryNameCleaned = replace(containerRegistryName, '-', '')
+var acrName = 'kmcontainerreg'
 
 var baseUrl = 'https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/main/'
 
@@ -226,7 +226,7 @@ module backend_docker 'deploy_backend_docker.bicep' = {
     userassignedIdentityId: managedIdentityModule.outputs.managedIdentityBackendAppOutput.id
     keyVaultName: kvault.outputs.keyvaultName
     aiServicesName: aifoundry.outputs.aiServicesName
-    useLocalBuild: useLocalBuildLower
+    // useLocalBuild: useLocalBuildLower
     azureExistingAIProjectResourceId: azureExistingAIProjectResourceId
     aiSearchName: aifoundry.outputs.aiSearchName 
     appSettings: {
@@ -269,7 +269,7 @@ module frontend_docker 'deploy_frontend_docker.bicep' = {
     acrName: acrName
     appServicePlanId: hostingplan.outputs.name
     applicationInsightsId: aifoundry.outputs.applicationInsightsId
-    useLocalBuild: useLocalBuildLower
+    // useLocalBuild: useLocalBuildLower
     appSettings:{
       APP_API_BASE_URL:backend_docker.outputs.appUrl
     }
@@ -319,3 +319,8 @@ output AZURE_ENV_IMAGETAG string = imageTag
 output API_APP_URL string = backend_docker.outputs.appUrl
 output WEB_APP_URL string = frontend_docker.outputs.appUrl
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = aifoundry.outputs.applicationInsightsConnectionString
+
+output BACKEND_APP_NAME string = backend_docker.outputs.backendAppName
+output FRONTEND_APP_NAME string = frontend_docker.outputs.frontendAppName
+output BACKEND_MANAGED_IDENTITY_PRINCIPAL_ID string = backend_docker.outputs.backendManagedIdentityPrincipalId
+output FRONTEND_MANAGED_IDENTITY_PRINCIPAL_ID string = frontend_docker.outputs.frontendManagedIdentityPrincipalId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -66,12 +66,6 @@ param imageTag string = 'latest_fdp'
 param AZURE_LOCATION string=''
 var solutionLocation = empty(AZURE_LOCATION) ? resourceGroup().location : AZURE_LOCATION
 
-// @description('Set this flag to true only if you are deploying from Local')
-// param useLocalBuild string = 'false'
-
-// // Convert input to lowercase
-// var useLocalBuildLower = toLower(useLocalBuild)
-
 var uniqueId = toLower(uniqueString(subscription().id, environmentName, solutionLocation))
 
 
@@ -89,8 +83,6 @@ param aiDeploymentsLocation string
 
 var solutionPrefix = 'km${padLeft(take(uniqueId, 12), 12, '0')}'
 
-// var containerRegistryName = '${abbrs.containers.containerRegistry}${solutionPrefix}'
-// var containerRegistryNameCleaned = replace(containerRegistryName, '-', '')
 var acrName = 'kmcontainerreg'
 
 var baseUrl = 'https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/main/'
@@ -226,7 +218,6 @@ module backend_docker 'deploy_backend_docker.bicep' = {
     userassignedIdentityId: managedIdentityModule.outputs.managedIdentityBackendAppOutput.id
     keyVaultName: kvault.outputs.keyvaultName
     aiServicesName: aifoundry.outputs.aiServicesName
-    // useLocalBuild: useLocalBuildLower
     azureExistingAIProjectResourceId: azureExistingAIProjectResourceId
     aiSearchName: aifoundry.outputs.aiSearchName 
     appSettings: {
@@ -269,7 +260,6 @@ module frontend_docker 'deploy_frontend_docker.bicep' = {
     acrName: acrName
     appServicePlanId: hostingplan.outputs.name
     applicationInsightsId: aifoundry.outputs.applicationInsightsId
-    // useLocalBuild: useLocalBuildLower
     appSettings:{
       APP_API_BASE_URL:backend_docker.outputs.appUrl
     }

--- a/infra/scripts/docker-build.ps1
+++ b/infra/scripts/docker-build.ps1
@@ -188,3 +188,5 @@ Update-WebApp-Image -WebAppName $WEB_APP_NAME -ResourceGroup $AZURE_RESOURCE_GRO
 Update-WebApp-Image -WebAppName $API_APP_NAME -ResourceGroup $AZURE_RESOURCE_GROUP -Image "$ACR_NAME.azurecr.io/km-api:$AZURE_ENV_IMAGETAG"
 
 Write-Host "`nWeb Apps updated successfully to use new images"
+
+Write-Host "`nIt might take a few minutes for the changes to take effect.`n"

--- a/infra/scripts/docker-build.sh
+++ b/infra/scripts/docker-build.sh
@@ -177,3 +177,5 @@ update_web_app_image "$WEB_APP_NAME" "$AZURE_RESOURCE_GROUP" "$ACR_NAME.azurecr.
 update_web_app_image "$API_APP_NAME" "$AZURE_RESOURCE_GROUP" "$ACR_NAME.azurecr.io/km-api:$AZURE_ENV_IMAGETAG"
 
 echo -e "\nWeb Apps updated successfully to use new images"
+
+echo -e "\nIt might take a few minutes for the changes to take effect.\n"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces significant changes to simplify and improve the deployment process by removing the `useLocalBuild` parameter and implementing a more robust container registry and managed identity-based workflow. The changes span across multiple files, including Bicep templates, documentation, and deployment scripts. Below is a summary of the most important changes grouped by theme.

### Removal of `useLocalBuild` Parameter:
* Removed the `useLocalBuild` parameter from multiple Bicep templates (`infra/deploy_app_service.bicep`, `infra/deploy_backend_docker.bicep`, `infra/deploy_frontend_docker.bicep`, `infra/main.bicep`) and associated logic for conditional ACR role assignments. [[1]](diffhunk://#diff-37c8b5694d17291d641a19fb8a562e30642066b4bf8b8657f2636f50567cf4ebL15) [[2]](diffhunk://#diff-7934b4de99efd4cba4578f74c59fefa78d390bdac7b0037b19300f96361c4db1L14) [[3]](diffhunk://#diff-e422a0be1b39e2563a2546e21ab3a83e5ad20e969c5129a3243e5f443c6cda09L11) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L69-L74)
* Eliminated conditional resource definitions for container registry and role assignments based on `useLocalBuild`. [[1]](diffhunk://#diff-7934b4de99efd4cba4578f74c59fefa78d390bdac7b0037b19300f96361c4db1L179-R182) [[2]](diffhunk://#diff-e422a0be1b39e2563a2546e21ab3a83e5ad20e969c5129a3243e5f443c6cda09L33-R34)

### Enhanced Container Registry Configuration:
* Added new parameters (`acrPullPrincipalIds`, `acrSku`) to `infra/deploy_container_registry.bicep` to support role assignments and customizable ACR tier. [[1]](diffhunk://#diff-b93aa77f0f8c7e53dd1b38816ca03f154766480be6378867019975283fb17cc6R12-R22) [[2]](diffhunk://#diff-b93aa77f0f8c7e53dd1b38816ca03f154766480be6378867019975283fb17cc6R48-R60)

### Improved Deployment Scripts:
* Refactored `infra/scripts/docker-build.ps1` to dynamically fetch environment values using `azd env get-values` and removed reliance on `useLocalBuild`. Added steps to update web app settings and restart web apps after image deployment. [[1]](diffhunk://#diff-bbd8ac6fc2f33cfdb70dd2aad3a606da6e0dae8518301f42797c548c040a9939L1-R53) [[2]](diffhunk://#diff-bbd8ac6fc2f33cfdb70dd2aad3a606da6e0dae8518301f42797c548c040a9939L113-R192)

### Documentation Updates:
* Removed references to `USE_LOCAL_BUILD` from documentation files (`documents/CustomizingAzdParameters.md`, `documents/DeploymentGuide.md`) and added instructions for publishing local build containers. [[1]](diffhunk://#diff-2e319e20f66e2cd84d3764f457565dbc3fe39c15edc9d7c05801ff16c423598aL25) [[2]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L123) [[3]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5R189-R206)

### Workflow Enhancements:
* Updated `.github/workflows/test-automation.yml` to use `workflow_call` for reusability, removing branch-specific triggers.

These changes collectively simplify the deployment process, improve maintainability, and enhance support for managed identities and container registry configurations.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

