### PR TITLE
fix: updated main.json - to update base url

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "12404979401636629434"
+      "templateHash": "832352662399817246"
     }
   },
   "parameters": {
@@ -382,7 +382,7 @@
     "containerRegistryName": "[format('{0}{1}', variables('abbrs').containers.containerRegistry, variables('solutionPrefix'))]",
     "containerRegistryNameCleaned": "[replace(variables('containerRegistryName'), '-', '')]",
     "acrName": "[if(equals(variables('useLocalBuildLower'), 'true'), variables('containerRegistryNameCleaned'), 'kmcontainerreg')]",
-    "baseUrl": "https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/psl-pk-modelexisting/"
+    "baseUrl": "https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/main/"
   },
   "resources": [
     {


### PR DESCRIPTION
## Purpose
This pull request updates the `infra/main.json` file to reflect changes in template hash and resource URLs, ensuring alignment with the latest configurations and repository structure.

Configuration updates:

* Updated the `_generator.templateHash` value to reflect a new hash, likely due to changes in the template or generator version. (`[infra/main.jsonL8-R8](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8)`)

Resource URL updates:

* Changed the `baseUrl` parameter to point to the `main` branch of the repository instead of the `psl-pk-modelexisting` branch, ensuring the solution uses the most up-to-date resources. (`[infra/main.jsonL385-R385](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L385-R385)`)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No
