### PR TITLE
fix: add principalType as 'ServicePrincipal' for role assignments

### DIFF
--- a/infra/deploy_backend_docker.bicep
+++ b/infra/deploy_backend_docker.bicep
@@ -143,6 +143,7 @@ resource keyVaultSecretsUserAssignment 'Microsoft.Authorization/roleAssignments@
   properties: {
     roleDefinitionId: keyVaultSecretsUser.id
     principalId: appService.outputs.identityPrincipalId
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -160,6 +161,7 @@ resource searchIndexDataReaderAssignment 'Microsoft.Authorization/roleAssignment
   properties: {
     roleDefinitionId: searchIndexDataReader.id
     principalId: appService.outputs.identityPrincipalId
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -203,6 +205,7 @@ resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
   properties: {
     roleDefinitionId: AcrPull.id
     principalId: appService.outputs.identityPrincipalId
+    principalType: 'ServicePrincipal'
   }
 }
 

--- a/infra/deploy_foundry_role_assignment.bicep
+++ b/infra/deploy_foundry_role_assignment.bicep
@@ -80,6 +80,7 @@ resource roleAssignmentToFoundryExisting 'Microsoft.Authorization/roleAssignment
   properties: {
     roleDefinitionId: roleDefinitionId
     principalId: principalId
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -89,6 +90,7 @@ resource roleAssignmentToFoundry 'Microsoft.Authorization/roleAssignments@2022-0
   properties: {
     roleDefinitionId: roleDefinitionId
     principalId: principalId
+    principalType: 'ServicePrincipal'
   }
 }
 

--- a/infra/deploy_frontend_docker.bicep
+++ b/infra/deploy_frontend_docker.bicep
@@ -44,6 +44,7 @@ resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
   properties: {
     roleDefinitionId: AcrPull.id
     principalId: appService.outputs.identityPrincipalId
+    principalType: 'ServicePrincipal'
   }
 }
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -1834,7 +1834,8 @@
                       "name": "[parameters('roleAssignmentName')]",
                       "properties": {
                         "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "principalId": "[parameters('principalId')]"
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "ServicePrincipal"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]"
@@ -1848,7 +1849,8 @@
                       "name": "[parameters('roleAssignmentName')]",
                       "properties": {
                         "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "principalId": "[parameters('principalId')]"
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "ServicePrincipal"
                       }
                     }
                   ],
@@ -2043,7 +2045,8 @@
                       "name": "[parameters('roleAssignmentName')]",
                       "properties": {
                         "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "principalId": "[parameters('principalId')]"
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "ServicePrincipal"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]"
@@ -2057,7 +2060,8 @@
                       "name": "[parameters('roleAssignmentName')]",
                       "properties": {
                         "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "principalId": "[parameters('principalId')]"
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "ServicePrincipal"
                       }
                     }
                   ],
@@ -3293,7 +3297,8 @@
               "name": "[guid(format('{0}-app-module', parameters('name')), parameters('keyVaultName'), resourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6'))]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
-                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]"
+                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]",
+                "principalType": "ServicePrincipal"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name')))]"
@@ -3306,7 +3311,8 @@
               "name": "[guid(format('{0}-app-module', parameters('name')), parameters('aiSearchName'), resourceId('Microsoft.Authorization/roleDefinitions', '1407120a-92aa-4202-b7e9-c0e197c71c8f'))]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '1407120a-92aa-4202-b7e9-c0e197c71c8f')]",
-                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]"
+                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]",
+                "principalType": "ServicePrincipal"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name')))]"
@@ -3320,7 +3326,8 @@
               "name": "[guid(format('{0}-app-module', parameters('name')), resourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]"
+                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]",
+                "principalType": "ServicePrincipal"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name')))]"
@@ -3805,7 +3812,8 @@
                       "name": "[parameters('roleAssignmentName')]",
                       "properties": {
                         "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "principalId": "[parameters('principalId')]"
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "ServicePrincipal"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]"
@@ -3819,7 +3827,8 @@
                       "name": "[parameters('roleAssignmentName')]",
                       "properties": {
                         "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "principalId": "[parameters('principalId')]"
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "ServicePrincipal"
                       }
                     }
                   ],
@@ -3955,7 +3964,8 @@
               "name": "[guid(format('{0}-app-module', parameters('name')), resourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]"
+                "principalId": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.identityPrincipalId.value]",
+                "principalType": "ServicePrincipal"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name')))]"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request standardizes the role assignment configurations across multiple infrastructure files by explicitly adding the `principalType: 'ServicePrincipal'` property to ensure clarity and consistency in the role assignment definitions. These changes affect several Bicep and JSON files used for deploying backend, frontend, and foundry resources.

### Standardization of Role Assignment Configurations:
* **Backend Deployment (`infra/deploy_backend_docker.bicep`)**:
  - Added `principalType: 'ServicePrincipal'` to `keyVaultSecretsUserAssignment`, `searchIndexDataReaderAssignment`, and `acrPullRoleAssignment` resources. [[1]](diffhunk://#diff-7934b4de99efd4cba4578f74c59fefa78d390bdac7b0037b19300f96361c4db1R146) [[2]](diffhunk://#diff-7934b4de99efd4cba4578f74c59fefa78d390bdac7b0037b19300f96361c4db1R164) [[3]](diffhunk://#diff-7934b4de99efd4cba4578f74c59fefa78d390bdac7b0037b19300f96361c4db1R208)

* **Frontend Deployment (`infra/deploy_frontend_docker.bicep`)**:
  - Added `principalType: 'ServicePrincipal'` to `acrPullRoleAssignment` resource.

* **Foundry Role Assignment (`infra/deploy_foundry_role_assignment.bicep`)**:
  - Added `principalType: 'ServicePrincipal'` to `roleAssignmentToFoundryExisting` and `roleAssignmentToFoundry` resources. [[1]](diffhunk://#diff-14e63a7cd6462bdb2d4ca3a194ccf9b80e4a49512ede9eddd720dd0316d72809R83) [[2]](diffhunk://#diff-14e63a7cd6462bdb2d4ca3a194ccf9b80e4a49512ede9eddd720dd0316d72809R93)

* **Main Infrastructure Configuration (`infra/main.json`)**:
  - Added `principalType: 'ServicePrincipal'` to multiple role assignments for `roleAssignmentName`, `keyVaultName`, `aiSearchName`, and other resources to ensure consistent handling of principal types. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1837-R1838) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1851-R1853) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2046-R2049) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2060-R2064) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3296-R3301) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3309-R3315) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3323-R3330) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3808-R3816) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3822-R3831) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3958-R3968)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

