### PR TITLE
fix: Use ManagedIdentityCredential with Configurable Client ID

### DIFF
--- a/src/api/common/database/sqldb_service.py
+++ b/src/api/common/database/sqldb_service.py
@@ -19,7 +19,7 @@ async def get_db_connection():
     password = config.sqldb_database
     driver = config.driver
     mid_id = config.mid_id
-    
+
     try:
         async with ManagedIdentityCredential(client_id=mid_id) as credential:
             token = await credential.get_token("https://database.windows.net/.default")

--- a/src/api/common/database/sqldb_service.py
+++ b/src/api/common/database/sqldb_service.py
@@ -18,9 +18,10 @@ async def get_db_connection():
     username = config.sqldb_username
     password = config.sqldb_database
     driver = config.driver
-
+    mid_id = config.mid_id
+    
     try:
-        async with ManagedIdentityCredential() as credential:
+        async with ManagedIdentityCredential(client_id=mid_id) as credential:
             token = await credential.get_token("https://database.windows.net/.default")
             token_bytes = token.token.encode("utf-16-LE")
             token_struct = struct.pack(


### PR DESCRIPTION
## Purpose
This pull request introduces a minor update to the `get_db_connection` function in `src/api/common/database/sqldb_service.py`. The change enhances the function to use a `client_id` for the `ManagedIdentityCredential`, improving the configuration flexibility.

* [`src/api/common/database/sqldb_service.py`](diffhunk://#diff-a4829106285a4d5ecc980ddbc6392e949639599ed516c0b2b3d42b24244da2aaR21-R24): Added a `mid_id` variable to retrieve the `client_id` from the configuration and updated the `ManagedIdentityCredential` instantiation to use `client_id=mid_id`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
