### PR TITLE
refactor: Credential Handling: Replace DefaultAzureCredential with AzureCliCredential

### DIFF
--- a/docs/workshop/docs/workshop/Challenge-5/python/content_understanding_client.py
+++ b/docs/workshop/docs/workshop/Challenge-5/python/content_understanding_client.py
@@ -32,13 +32,13 @@ class AzureContentUnderstandingClient:
         )
 
     def _get_analyzer_url(self, endpoint, api_version, analyzer_id):
-        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}?api-version={api_version}"  # noqa
+        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}?api-version={api_version}"
 
     def _get_analyzer_list_url(self, endpoint, api_version):
         return f"{endpoint}/contentunderstanding/analyzers?api-version={api_version}"
 
     def _get_analyze_url(self, endpoint, api_version, analyzer_id):
-        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}:analyze?api-version={api_version}"  # noqa
+        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}:analyze?api-version={api_version}"
 
     def _get_training_data_config(
         self, storage_container_sas_url, storage_container_path_prefix
@@ -143,7 +143,7 @@ class AzureContentUnderstandingClient:
         if (
             training_storage_container_sas_url
             and training_storage_container_path_prefix
-        ):  # noqa
+        ):
             analyzer_template["trainingData"] = self._get_training_data_config(
                 training_storage_container_sas_url,
                 training_storage_container_path_prefix,

--- a/infra/scripts/index_scripts/azure_credential_utils.py
+++ b/infra/scripts/index_scripts/azure_credential_utils.py
@@ -1,4 +1,4 @@
-from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential
 
 APP_ENV = 'prod'  # Change to 'dev' for local development
 
@@ -13,10 +13,10 @@ def get_azure_credential(client_id=None):
         client_id (str, optional): The client ID for the managed identity. Defaults to None.
 
     Returns:
-        azure.identity.DefaultAzureCredential or azure.identity.ManagedIdentityCredential: 
+        azure.identity.AzureCliCredential or azure.identity.ManagedIdentityCredential: 
         The Azure credential object.
     """
     if APP_ENV == 'dev':
-        return DefaultAzureCredential() # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+        return AzureCliCredential()
     else:
         return ManagedIdentityCredential(client_id=client_id)

--- a/infra/scripts/index_scripts/content_understanding_client.py
+++ b/infra/scripts/index_scripts/content_understanding_client.py
@@ -32,13 +32,13 @@ class AzureContentUnderstandingClient:
         )
 
     def _get_analyzer_url(self, endpoint, api_version, analyzer_id):
-        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}?api-version={api_version}"  # noqa
+        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}?api-version={api_version}"
 
     def _get_analyzer_list_url(self, endpoint, api_version):
         return f"{endpoint}/contentunderstanding/analyzers?api-version={api_version}"
 
     def _get_analyze_url(self, endpoint, api_version, analyzer_id):
-        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}:analyze?api-version={api_version}"  # noqa
+        return f"{endpoint}/contentunderstanding/analyzers/{analyzer_id}:analyze?api-version={api_version}"
 
     def _get_training_data_config(
         self, storage_container_sas_url, storage_container_path_prefix
@@ -143,7 +143,7 @@ class AzureContentUnderstandingClient:
         if (
             training_storage_container_sas_url
             and training_storage_container_path_prefix
-        ):  # noqa
+        ):
             analyzer_template["trainingData"] = self._get_training_data_config(
                 training_storage_container_sas_url,
                 training_storage_container_path_prefix,

--- a/src/api/helpers/azure_credential_utils.py
+++ b/src/api/helpers/azure_credential_utils.py
@@ -1,23 +1,23 @@
 import os
-from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
-from azure.identity.aio import ManagedIdentityCredential as AioManagedIdentityCredential, DefaultAzureCredential as AioDefaultAzureCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential
+from azure.identity.aio import ManagedIdentityCredential as AioManagedIdentityCredential, AzureCliCredential as AioAzureCliCredential
 
 
 async def get_azure_credential_async(client_id=None):
     """
     Returns an Azure credential asynchronously based on the application environment.
 
-    If the environment is 'dev', it uses AioDefaultAzureCredential.
+    If the environment is 'dev', it uses AioAzureCliCredential.
     Otherwise, it uses AioManagedIdentityCredential.
 
     Args:
         client_id (str, optional): The client ID for the Managed Identity Credential.
 
     Returns:
-        Credential object: Either AioDefaultAzureCredential or AioManagedIdentityCredential.
+        Credential object: Either AioAzureCliCredential or AioManagedIdentityCredential.
     """
     if os.getenv("APP_ENV", "prod").lower() == 'dev':
-        return AioDefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+        return AioAzureCliCredential()
     else:
         return AioManagedIdentityCredential(client_id=client_id)
 
@@ -26,16 +26,16 @@ def get_azure_credential(client_id=None):
     """
     Returns an Azure credential based on the application environment.
 
-    If the environment is 'dev', it uses DefaultAzureCredential.
+    If the environment is 'dev', it uses AzureCliCredential.
     Otherwise, it uses ManagedIdentityCredential.
 
     Args:
         client_id (str, optional): The client ID for the Managed Identity Credential.
 
     Returns:
-        Credential object: Either DefaultAzureCredential or ManagedIdentityCredential.
+        Credential object: Either AzureCliCredential or ManagedIdentityCredential.
     """
     if os.getenv("APP_ENV", "prod").lower() == 'dev':
-        return DefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+        return AzureCliCredential()
     else:
         return ManagedIdentityCredential(client_id=client_id)

--- a/src/tests/api/helpers/test_azure_credential_utils.py
+++ b/src/tests/api/helpers/test_azure_credential_utils.py
@@ -15,27 +15,27 @@ def mock_env_vars():
 
 class TestAzureCredentialUtils:
     @patch.dict(os.environ, {}, clear=True)
-    @patch("helpers.azure_credential_utils.DefaultAzureCredential")
+    @patch("helpers.azure_credential_utils.AzureCliCredential")
     @patch("helpers.azure_credential_utils.ManagedIdentityCredential")
-    def test_get_azure_credential_dev_env(self, mock_managed_identity_credential, mock_default_azure_credential, mock_env_vars):
+    def test_get_azure_credential_dev_env(self, mock_managed_identity_credential, mock_azure_cli_credential, mock_env_vars):
         """Test get_azure_credential in dev environment."""
         # Arrange
         os.environ.update(mock_env_vars)
-        mock_default_credential = MagicMock()
-        mock_default_azure_credential.return_value = mock_default_credential
+        mock_azure_cli_credential = MagicMock()
+        mock_azure_cli_credential.return_value = mock_azure_cli_credential
 
         # Act
         credential = azure_credential_utils.get_azure_credential()
 
         # Assert
-        mock_default_azure_credential.assert_called_once()
+        mock_azure_cli_credential.assert_called_once()
         mock_managed_identity_credential.assert_not_called()
-        assert credential == mock_default_credential
+        assert credential == mock_azure_cli_credential
 
     @patch.dict(os.environ, {}, clear=True)
-    @patch("helpers.azure_credential_utils.DefaultAzureCredential")
+    @patch("helpers.azure_credential_utils.AzureCliCredential")
     @patch("helpers.azure_credential_utils.ManagedIdentityCredential")
-    def test_get_azure_credential_non_dev_env(self, mock_managed_identity_credential, mock_default_azure_credential, mock_env_vars):
+    def test_get_azure_credential_non_dev_env(self, mock_managed_identity_credential, mock_azure_cli_credential, mock_env_vars):
         """Test get_azure_credential in non-dev environment."""
         # Arrange
         mock_env_vars["APP_ENV"] = "prod"
@@ -48,33 +48,33 @@ class TestAzureCredentialUtils:
 
         # Assert
         mock_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
-        mock_default_azure_credential.assert_not_called()
+        mock_azure_cli_credential.assert_not_called()
         assert credential == mock_managed_credential
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {}, clear=True)
-    @patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+    @patch("helpers.azure_credential_utils.AioAzureCliCredential")
     @patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
-    async def test_get_azure_credential_async_dev_env(self, mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_env_vars):
+    async def test_get_azure_credential_async_dev_env(self, mock_aio_managed_identity_credential, mock_aio_azure_cli_credential, mock_env_vars):
         """Test get_azure_credential_async in dev environment."""
         # Arrange
         os.environ.update(mock_env_vars)
-        mock_aio_default_credential = MagicMock()
-        mock_aio_default_azure_credential.return_value = mock_aio_default_credential
+        mock_aio_azure_cli_credential = MagicMock()
+        mock_aio_azure_cli_credential.return_value = mock_aio_azure_cli_credential
 
         # Act
         credential = await azure_credential_utils.get_azure_credential_async()
 
         # Assert
-        mock_aio_default_azure_credential.assert_called_once()
+        mock_aio_azure_cli_credential.assert_called_once()
         mock_aio_managed_identity_credential.assert_not_called()
-        assert credential == mock_aio_default_credential
+        assert credential == mock_aio_azure_cli_credential
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {}, clear=True)
-    @patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+    @patch("helpers.azure_credential_utils.AioAzureCliCredential")
     @patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
-    async def test_get_azure_credential_async_non_dev_env(self, mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_env_vars):
+    async def test_get_azure_credential_async_non_dev_env(self, mock_aio_managed_identity_credential, mock_aio_azure_cli_credential, mock_env_vars):
         """Test get_azure_credential_async in non-dev environment."""
         # Arrange
         mock_env_vars["APP_ENV"] = "prod"
@@ -87,5 +87,5 @@ class TestAzureCredentialUtils:
 
         # Assert
         mock_aio_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
-        mock_aio_default_azure_credential.assert_not_called()
+        mock_aio_azure_cli_credential.assert_not_called()
         assert credential == mock_aio_managed_credential

--- a/src/tests/api/helpers/test_azure_credential_utils.py
+++ b/src/tests/api/helpers/test_azure_credential_utils.py
@@ -21,8 +21,8 @@ class TestAzureCredentialUtils:
         """Test get_azure_credential in dev environment."""
         # Arrange
         os.environ.update(mock_env_vars)
-        mock_azure_cli_credential = MagicMock()
-        mock_azure_cli_credential.return_value = mock_azure_cli_credential
+        mock_credential_instance = MagicMock()
+        mock_azure_cli_credential.return_value = mock_credential_instance
 
         # Act
         credential = azure_credential_utils.get_azure_credential()
@@ -30,7 +30,8 @@ class TestAzureCredentialUtils:
         # Assert
         mock_azure_cli_credential.assert_called_once()
         mock_managed_identity_credential.assert_not_called()
-        assert credential == mock_azure_cli_credential
+        assert credential == mock_credential_instance
+
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("helpers.azure_credential_utils.AzureCliCredential")
@@ -59,8 +60,8 @@ class TestAzureCredentialUtils:
         """Test get_azure_credential_async in dev environment."""
         # Arrange
         os.environ.update(mock_env_vars)
-        mock_aio_azure_cli_credential = MagicMock()
-        mock_aio_azure_cli_credential.return_value = mock_aio_azure_cli_credential
+        mock_credential_instance = MagicMock()
+        mock_aio_azure_cli_credential.return_value = mock_credential_instance
 
         # Act
         credential = await azure_credential_utils.get_azure_credential_async()
@@ -68,7 +69,7 @@ class TestAzureCredentialUtils:
         # Assert
         mock_aio_azure_cli_credential.assert_called_once()
         mock_aio_managed_identity_credential.assert_not_called()
-        assert credential == mock_aio_azure_cli_credential
+        assert credential == mock_credential_instance
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
## Purpose
This pull request updates the Azure credential logic across several scripts and modules to use `AzureCliCredential` instead of `DefaultAzureCredential` for development environments. It also updates related tests and documentation to reflect this change, ensuring consistency and clarity throughout the codebase. Additionally, some minor cleanups were made to remove unnecessary comments.

**Azure Credential Logic Updates:**

* Switched development environment credential from `DefaultAzureCredential` to `AzureCliCredential` in `src/api/helpers/azure_credential_utils.py` and its async variant, as well as in `infra/scripts/index_scripts/azure_credential_utils.py`. All type hints, docstrings, and credential returns were updated accordingly. [[1]](diffhunk://#diff-02f9239eed75604905996397a7a36dea822e715298eaceda4da44a3954605254L2-R20) [[2]](diffhunk://#diff-02f9239eed75604905996397a7a36dea822e715298eaceda4da44a3954605254L29-R39) [[3]](diffhunk://#diff-fda744d16c1425c3d007316579b967001ac5e55eacc1f13871c569161460b54eL1-R1) [[4]](diffhunk://#diff-fda744d16c1425c3d007316579b967001ac5e55eacc1f13871c569161460b54eL16-R20)

**Test Updates:**

* Modified all related tests in `src/tests/api/helpers/test_azure_credential_utils.py` to mock and assert usage of `AzureCliCredential` (and its async variant) instead of `DefaultAzureCredential`, ensuring tests accurately reflect the new credential logic. [[1]](diffhunk://#diff-a9752ecad9a1e3ea115b2e7d011ab10e686fe45d2d823a6678a0318944eae459L18-R38) [[2]](diffhunk://#diff-a9752ecad9a1e3ea115b2e7d011ab10e686fe45d2d823a6678a0318944eae459L51-R77) [[3]](diffhunk://#diff-a9752ecad9a1e3ea115b2e7d011ab10e686fe45d2d823a6678a0318944eae459L90-R90)

**Minor Cleanups:**

* Removed unnecessary `# noqa` comments from URL construction methods in `content_understanding_client.py` for both `docs/workshop/Challenge-5/python` and `infra/scripts/index_scripts` directories, improving code readability. [[1]](diffhunk://#diff-df09ca9e0470a69e70e17ee9b15a310538c73c10d612e218ad81d2baf026be94L35-R41) [[2]](diffhunk://#diff-df09ca9e0470a69e70e17ee9b15a310538c73c10d612e218ad81d2baf026be94L146-R146) [[3]](diffhunk://#diff-f734e1595403d44078507080698a1db85aaa1b307bdb4d5747d44403c9b5889bL35-R41) [[4]](diffhunk://#diff-f734e1595403d44078507080698a1db85aaa1b307bdb4d5747d44403c9b5889bL146-R146)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

