### PR TITLE
feat: KMGenric Bicep Standard Changes (output vars changed to caps)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -312,129 +312,126 @@ module frontend_docker 'deploy_frontend_docker.bicep' = {
   scope: resourceGroup(resourceGroup().name)
 }
 
-
-@description('Contains Solution Prefix.')
-output solutionSuffix string = solutionSuffix
+@description('Contains Solution Name.')
+output SOLUTION_NAME string = solutionSuffix
 
 @description('Contains Resource Group Name.')
-output resourceGroupName string = resourceGroup().name
+output RESOURCE_GROUP_NAME string = resourceGroup().name
 
 @description('Contains Resource Group Location.')
-output resourceGroupLocation string = solutionLocation
-
-@description('Contains Environment Name.')
-output solutionName string = solutionName
+output RESOURCE_GROUP_LOCATION string = solutionLocation
 
 @description('Contains Azure Content Understanding Location.')
-output azureContentUnderstandingLocation string = contentUnderstandingLocation
+output AZURE_CONTENT_UNDERSTANDING_LOCATION string = contentUnderstandingLocation
 
 @description('Contains Azure Secondary Location.')
-output azureSecondaryLocation string = secondaryLocation
+output AZURE_SECONDARY_LOCATION string = secondaryLocation
 
-@description('Contains AppInsights Instrumentation Key.')
-output appInsightsInstrumentationKey string = backend_docker.outputs.appInsightInstrumentationKey
+@description('Contains Application Insights Instrumentation Key.')
+output APPINSIGHTS_INSTRUMENTATIONKEY string = backend_docker.outputs.appInsightInstrumentationKey
 
 @description('Contains AI Project Connection String.')
-output azureAiProjectConnectionString string = aifoundry.outputs.projectEndpoint
+output AZURE_AI_PROJECT_CONN_STRING string = aifoundry.outputs.projectEndpoint
 
-@description('Contains AI Agent API Version.')
-output azureAiAgentApiVersion string = azureAiAgentApiVersion
 
-@description('Contains AI Foundry Name Name.')
-output azureAiFoundryName string = aifoundry.outputs.aiServicesName
+@description('Contains Azure AI Agent API Version.')
+output AZURE_AI_AGENT_API_VERSION string = azureAiAgentApiVersion
 
-@description('Contains AI Project Name.')
-output azureAiProjectName string = aifoundry.outputs.aiProjectName
+@description('Contains Azure AI Foundry service name.')
+output AZURE_AI_FOUNDRY_NAME string = aifoundry.outputs.aiServicesName
 
-@description('Contains AI Search Name.')
-output azureAiSearchName string = aifoundry.outputs.aiSearchName
+@description('Contains Azure AI Project name.')
+output AZURE_AI_PROJECT_NAME string = aifoundry.outputs.aiProjectName
 
-@description('Contains AI Search Endpoint.')
-output azureAiSearchEndpoint string = aifoundry.outputs.aiSearchTarget
+@description('Contains Azure AI Search service name.')
+output AZURE_AI_SEARCH_NAME string = aifoundry.outputs.aiSearchName
 
-@description('Contains AI Search Index.')
-output azureAiSearchIndex string = 'call_transcripts_index'
+@description('Contains Azure AI Search endpoint URL.')
+output AZURE_AI_SEARCH_ENDPOINT string = aifoundry.outputs.aiSearchTarget
 
-@description('Contains AI Search Connection Name.')
-output azureAiSearchConnectionName string = aifoundry.outputs.aiSearchConnectionName
+@description('Contains Azure AI Search index name.')
+output AZURE_AI_SEARCH_INDEX string = 'call_transcripts_index'
 
-@description('Contains Azure Cosmos DB Account.')
-output azureCosmosDbAccount string = cosmosDBModule.outputs.cosmosAccountName
+@description('Contains Azure AI Search connection name.')
+output AZURE_AI_SEARCH_CONNECTION_NAME string = aifoundry.outputs.aiSearchConnectionName
 
-@description('Contains Azure Cosmos DB Conversations Container.')
-output azureCosmosDbConversationsContainer string = 'conversations'
+@description('Contains Azure Cosmos DB account name.')
+output AZURE_COSMOSDB_ACCOUNT string = cosmosDBModule.outputs.cosmosAccountName
 
-@description('Contains Azure Cosmos DB Database.')
-output azureCosmosDbDatabase string = 'db_conversation_history'
+@description('Contains Azure Cosmos DB conversations container name.')
+output AZURE_COSMOSDB_CONVERSATIONS_CONTAINER string = 'conversations'
 
-@description('Contains Cosmos DB Enable Feedback.')
-output azureCOSMOSDB_ENABLE_FEEDBACK string = 'True'
+@description('Contains Azure Cosmos DB database name.')
+output AZURE_COSMOSDB_DATABASE string = 'db_conversation_history'
 
-@description('Contains OpenAI Deployment Model.')
-output azureOpenaiDeploymentModel string = gptModelName
+@description('Contains Azure Cosmos DB feedback enablement setting.')
+output AZURE_COSMOSDB_ENABLE_FEEDBACK string = 'True'
 
-@description('Contains OpenAI Deployment Capacity.')
-output azureOpenaiDeploymentModelCapacity int = gptDeploymentCapacity
+@description('Contains Azure OpenAI deployment model name.')
+output AZURE_OPENAI_DEPLOYMENT_MODEL string = gptModelName
 
-@description('Contains OpenAI Endpoint.')
-output azureOpenaiENDPOINT string = aifoundry.outputs.aiServicesTarget
+@description('Contains Azure OpenAI deployment model capacity.')
+output AZURE_OPENAI_DEPLOYMENT_MODEL_CAPACITY int = gptDeploymentCapacity
 
-@description('Contains OpenAI Model Deployment Type.')
-output azureOpenaiModelDeploymentType string = deploymentType
+@description('Contains Azure OpenAI endpoint URL.')
+output AZURE_OPENAI_ENDPOINT string = aifoundry.outputs.aiServicesTarget
 
-@description('Contains OpenAI Embedding Model.')
-output azureOpenaiEmbeddingModel string = embeddingModel
+@description('Contains Azure OpenAI model deployment type.')
+output AZURE_OPENAI_MODEL_DEPLOYMENT_TYPE string = deploymentType
 
-@description('Contains OpenAI Embedding Model Capacity.')
-output azureOpenaiEmbeddingModelCapacity int = embeddingDeploymentCapacity
+@description('Contains Azure OpenAI embedding model name.')
+output AZURE_OPENAI_EMBEDDING_MODEL string = embeddingModel
 
-@description('Contains OpenAI API Version.')
-output azureOpenaiApiVersion string = azureOpenAIApiVersion
+@description('Contains Azure OpenAI embedding model capacity.')
+output AZURE_OPENAI_EMBEDDING_MODEL_CAPACITY int = embeddingDeploymentCapacity
 
-@description('Contains OpenAI Resource.')
-output azureOenaiResource string = aifoundry.outputs.aiServicesName
+@description('Contains Azure OpenAI API version.')
+output AZURE_OPENAI_API_VERSION string = azureOpenAIApiVersion
 
-@description('Contains React App Layout Config.')
-output reactAppLayoutConfig string = backend_docker.outputs.reactAppLayoutConfig
+@description('Contains Azure OpenAI resource name.')
+output AZURE_OPENAI_RESOURCE string = aifoundry.outputs.aiServicesName
 
-@description('Contains SQL Database.')
-output sqlDatabase string = sqlDBModule.outputs.sqlDbName
+@description('Contains React app layout configuration.')
+output REACT_APP_LAYOUT_CONFIG string = backend_docker.outputs.reactAppLayoutConfig
 
-@description('Contains SQL DB Server.')
-output sqlServer string = sqlDBModule.outputs.sqlServerName
+@description('Contains SQL database name.')
+output SQLDB_DATABASE string = sqlDBModule.outputs.sqlDbName
 
-@description('Contains SQL DB User MID.')
-output sqlUserMid string = managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId
+@description('Contains SQL server name.')
+output SQLDB_SERVER string = sqlDBModule.outputs.sqlServerName
 
-@description('Contains Use AI Project Client.')
-output useAiProjectClient string = 'False'
+@description('Contains SQL database user managed identity client ID.')
+output SQLDB_USER_MID string = managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId
 
-@description('To specify whether to Enable or Disable chat history.')
-output useChatHistoryEnabled string = 'True'
+@description('Contains AI project client usage setting.')
+output USE_AI_PROJECT_CLIENT string = 'False'
 
-@description('To specify whether to Enable or Disable Display Chart.')
-output displayChartDefault string = 'False'
+@description('Contains chat history enablement setting.')
+output USE_CHAT_HISTORY_ENABLED string = 'True'
 
-@description('Contains AI Agent Endpoint.')
-output azureAiAgentEndpoint string = aifoundry.outputs.projectEndpoint
+@description('Contains default chart display setting.')
+output DISPLAY_CHART_DEFAULT string = 'False'
 
-@description('Contains Azure AI Agent Model Deployment Name.')
-output azureAiAgentModelDeploymentName string = gptModelName
+@description('Contains Azure AI Agent endpoint URL.')
+output AZURE_AI_AGENT_ENDPOINT string = aifoundry.outputs.projectEndpoint
 
-@description('Contains ACR Name.')
-output acrName string = acrName
+@description('Contains Azure AI Agent model deployment name.')
+output AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME string = gptModelName
 
-@description('Contains Azure Environment Image Tag.')
-output azureEnvImageTag string = imageTag
+@description('Contains Azure Container Registry name.')
+output ACR_NAME string = acrName
 
-@description('Contains Existing AI Project Resource ID.')
-output azureExistingAiProjectResourceId string = azureExistingAIProjectResourceId
+@description('Contains Azure environment image tag.')
+output AZURE_ENV_IMAGETAG string = imageTag
 
-@description('Contains App Insights Connection String.')
-output applicationinsightsConnectionString string = aifoundry.outputs.applicationInsightsConnectionString
+@description('Contains existing AI project resource ID.')
+output AZURE_EXISTING_AI_PROJECT_RESOURCE_ID string = azureExistingAIProjectResourceId
 
-@description('Contains API App URL.')
-output apiAppUrl string = backend_docker.outputs.appUrl
+@description('Contains Application Insights connection string.')
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = aifoundry.outputs.applicationInsightsConnectionString
 
-@description('Contains Web App URL.')
-output webAppUrl string = frontend_docker.outputs.appUrl
+@description('Contains API application URL.')
+output API_APP_URL string = backend_docker.outputs.appUrl
+
+@description('Contains web application URL.')
+output WEB_APP_URL string = frontend_docker.outputs.appUrl

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "15835496612260713718"
+      "templateHash": "7263803858241829495"
     }
   },
   "parameters": {
@@ -13,7 +13,7 @@
       "type": "string",
       "defaultValue": "kmgen",
       "minLength": 3,
-      "maxLength": 15,
+      "maxLength": 16,
       "metadata": {
         "description": "Required. A unique prefix for all resources in this deployment. This should be 3-20 characters long:"
       }
@@ -214,14 +214,14 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "14018582955735545730"
+              "templateHash": "980762060893785293"
             }
           },
           "parameters": {
             "solutionName": {
               "type": "string",
               "minLength": 3,
-              "maxLength": 15,
+              "maxLength": 16,
               "metadata": {
                 "description": "Required. Contains Solution Name."
               }
@@ -511,14 +511,14 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "12414631690918811321"
+              "templateHash": "1168742782096335746"
             }
           },
           "parameters": {
             "solutionName": {
               "type": "string",
               "minLength": 3,
-              "maxLength": 15,
+              "maxLength": 16,
               "metadata": {
                 "description": "Required. Contains Solution Name"
               }
@@ -621,7 +621,7 @@
             "applicationInsightsName": "[format('appi-{0}', parameters('solutionName'))]",
             "keyvaultName": "[format('kv-{0}', parameters('solutionName'))]",
             "location": "[parameters('solutionLocation')]",
-            "aiProjectName": "[format('aifp-{0}', parameters('solutionName'))]",
+            "aiProjectName": "[format('proj-{0}', parameters('solutionName'))]",
             "aiSearchName": "[format('srch-{0}', parameters('solutionName'))]",
             "aiSearchConnectionName": "[format('myCon-{0}', parameters('solutionName'))]",
             "aiModelDeployments": [
@@ -3224,9 +3224,11 @@
               "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.applicationInsightsConnectionString.value]",
               "DUMMY_TEST": "True",
               "SOLUTION_NAME": "[variables('solutionSuffix')]",
-              "APP_ENV": "Prod",
-              "tags": "[parameters('tags')]"
+              "APP_ENV": "Prod"
             }
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
           }
         },
         "template": {
@@ -3236,7 +3238,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "17878509525074991970"
+              "templateHash": "5849646822810829341"
             }
           },
           "parameters": {
@@ -3306,6 +3308,13 @@
               "type": "string",
               "metadata": {
                 "description": "Required. Contains AI Search Name"
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Tags to be applied to the resources."
               }
             },
             "name": {
@@ -3389,6 +3398,9 @@
                   },
                   "appSettings": {
                     "value": "[union(parameters('appSettings'), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference(parameters('applicationInsightsId'), '2015-05-01').InstrumentationKey, 'REACT_APP_LAYOUT_CONFIG', variables('reactAppLayoutConfig')))]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
                   }
                 },
                 "template": {
@@ -3398,14 +3410,14 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.37.4.10188",
-                      "templateHash": "8138048450770439757"
+                      "templateHash": "17413180076880991152"
                     }
                   },
                   "parameters": {
                     "solutionName": {
                       "type": "string",
                       "minLength": 3,
-                      "maxLength": 15,
+                      "maxLength": 16,
                       "metadata": {
                         "description": "Required. Contains Solution Name."
                       }
@@ -3441,6 +3453,13 @@
                       "metadata": {
                         "description": "Optional. Contains User Assigned Identity ID."
                       }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {},
+                      "metadata": {
+                        "description": "Optional. Tags to be applied to the resources."
+                      }
                     }
                   },
                   "resources": [
@@ -3471,6 +3490,7 @@
                       "apiVersion": "2020-06-01",
                       "name": "[parameters('solutionName')]",
                       "location": "[parameters('solutionLocation')]",
+                      "tags": "[parameters('tags')]",
                       "identity": "[if(equals(parameters('userassignedIdentityId'), ''), createObject('type', 'SystemAssigned'), createObject('type', 'SystemAssigned, UserAssigned', 'userAssignedIdentities', createObject(format('{0}', parameters('userassignedIdentityId')), createObject())))]",
                       "properties": {
                         "serverFarmId": "[parameters('appServicePlanId')]",
@@ -3534,7 +3554,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.37.4.10188",
-                              "templateHash": "7659439093705514335"
+                              "templateHash": "17012486924716292048"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3542,7 +3562,7 @@
                             "name": {
                               "type": "string",
                               "metadata": {
-                                "description": "Required. The name of the app service resource within the current resource group scope."
+                                "description": "Required. The name of the app service resource within the current resource group scope"
                               }
                             },
                             "appSettings": {
@@ -3984,6 +4004,9 @@
           "outputs": {
             "appUrl": {
               "type": "string",
+              "metadata": {
+                "description": "Contains App URL."
+              },
               "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-app-module', parameters('name'))), '2022-09-01').outputs.appUrl.value]"
             },
             "reactAppLayoutConfig": {
@@ -4045,6 +4068,9 @@
             "value": {
               "APP_API_BASE_URL": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_backend_docker'), '2022-09-01').outputs.appUrl.value]"
             }
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
           }
         },
         "template": {
@@ -4054,7 +4080,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "176043280944113770"
+              "templateHash": "6862492752032861212"
             }
           },
           "parameters": {
@@ -4100,6 +4126,13 @@
               "metadata": {
                 "description": "Required. The name of the app service resource within the current resource group scope."
               }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Tags to be applied to the resources."
+              }
             }
           },
           "variables": {
@@ -4130,6 +4163,9 @@
                   },
                   "appSettings": {
                     "value": "[union(parameters('appSettings'), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference(parameters('applicationInsightsId'), '2015-05-01').InstrumentationKey))]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
                   }
                 },
                 "template": {
@@ -4139,14 +4175,14 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.37.4.10188",
-                      "templateHash": "8138048450770439757"
+                      "templateHash": "17413180076880991152"
                     }
                   },
                   "parameters": {
                     "solutionName": {
                       "type": "string",
                       "minLength": 3,
-                      "maxLength": 15,
+                      "maxLength": 16,
                       "metadata": {
                         "description": "Required. Contains Solution Name."
                       }
@@ -4182,6 +4218,13 @@
                       "metadata": {
                         "description": "Optional. Contains User Assigned Identity ID."
                       }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {},
+                      "metadata": {
+                        "description": "Optional. Tags to be applied to the resources."
+                      }
                     }
                   },
                   "resources": [
@@ -4212,6 +4255,7 @@
                       "apiVersion": "2020-06-01",
                       "name": "[parameters('solutionName')]",
                       "location": "[parameters('solutionLocation')]",
+                      "tags": "[parameters('tags')]",
                       "identity": "[if(equals(parameters('userassignedIdentityId'), ''), createObject('type', 'SystemAssigned'), createObject('type', 'SystemAssigned, UserAssigned', 'userAssignedIdentities', createObject(format('{0}', parameters('userassignedIdentityId')), createObject())))]",
                       "properties": {
                         "serverFarmId": "[parameters('appServicePlanId')]",
@@ -4275,7 +4319,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.37.4.10188",
-                              "templateHash": "7659439093705514335"
+                              "templateHash": "17012486924716292048"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4283,7 +4327,7 @@
                             "name": {
                               "type": "string",
                               "metadata": {
-                                "description": "Required. The name of the app service resource within the current resource group scope."
+                                "description": "Required. The name of the app service resource within the current resource group scope"
                               }
                             },
                             "appSettings": {
@@ -4347,297 +4391,290 @@
     }
   ],
   "outputs": {
-    "solutionSuffix": {
+    "SOLUTION_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains Solution Prefix."
+        "description": "Contains Solution Name."
       },
       "value": "[variables('solutionSuffix')]"
     },
-    "resourceGroupName": {
+    "RESOURCE_GROUP_NAME": {
       "type": "string",
       "metadata": {
         "description": "Contains Resource Group Name."
       },
       "value": "[resourceGroup().name]"
     },
-    "resourceGroupLocation": {
+    "RESOURCE_GROUP_LOCATION": {
       "type": "string",
       "metadata": {
         "description": "Contains Resource Group Location."
       },
       "value": "[variables('solutionLocation')]"
     },
-    "solutionName": {
-      "type": "string",
-      "metadata": {
-        "description": "Contains Environment Name."
-      },
-      "value": "[parameters('solutionName')]"
-    },
-    "azureContentUnderstandingLocation": {
+    "AZURE_CONTENT_UNDERSTANDING_LOCATION": {
       "type": "string",
       "metadata": {
         "description": "Contains Azure Content Understanding Location."
       },
       "value": "[parameters('contentUnderstandingLocation')]"
     },
-    "azureSecondaryLocation": {
+    "AZURE_SECONDARY_LOCATION": {
       "type": "string",
       "metadata": {
         "description": "Contains Azure Secondary Location."
       },
       "value": "[parameters('secondaryLocation')]"
     },
-    "appInsightsInstrumentationKey": {
+    "APPINSIGHTS_INSTRUMENTATIONKEY": {
       "type": "string",
       "metadata": {
-        "description": "Contains AppInsights Instrumentation Key."
+        "description": "Contains Application Insights Instrumentation Key."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_backend_docker'), '2022-09-01').outputs.appInsightInstrumentationKey.value]"
     },
-    "azureAiProjectConnectionString": {
+    "AZURE_AI_PROJECT_CONN_STRING": {
       "type": "string",
       "metadata": {
         "description": "Contains AI Project Connection String."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.projectEndpoint.value]"
     },
-    "azureAiAgentApiVersion": {
+    "AZURE_AI_AGENT_API_VERSION": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Agent API Version."
+        "description": "Contains Azure AI Agent API Version."
       },
       "value": "[parameters('azureAiAgentApiVersion')]"
     },
-    "azureAiFoundryName": {
+    "AZURE_AI_FOUNDRY_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Foundry Name Name."
+        "description": "Contains Azure AI Foundry service name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiServicesName.value]"
     },
-    "azureAiProjectName": {
+    "AZURE_AI_PROJECT_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Project Name."
+        "description": "Contains Azure AI Project name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiProjectName.value]"
     },
-    "azureAiSearchName": {
+    "AZURE_AI_SEARCH_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Search Name."
+        "description": "Contains Azure AI Search service name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchName.value]"
     },
-    "azureAiSearchEndpoint": {
+    "AZURE_AI_SEARCH_ENDPOINT": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Search Endpoint."
+        "description": "Contains Azure AI Search endpoint URL."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchTarget.value]"
     },
-    "azureAiSearchIndex": {
+    "AZURE_AI_SEARCH_INDEX": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Search Index."
+        "description": "Contains Azure AI Search index name."
       },
       "value": "call_transcripts_index"
     },
-    "azureAiSearchConnectionName": {
+    "AZURE_AI_SEARCH_CONNECTION_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Search Connection Name."
+        "description": "Contains Azure AI Search connection name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchConnectionName.value]"
     },
-    "azureCosmosDbAccount": {
+    "AZURE_COSMOSDB_ACCOUNT": {
       "type": "string",
       "metadata": {
-        "description": "Contains Azure Cosmos DB Account."
+        "description": "Contains Azure Cosmos DB account name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosAccountName.value]"
     },
-    "azureCosmosDbConversationsContainer": {
+    "AZURE_COSMOSDB_CONVERSATIONS_CONTAINER": {
       "type": "string",
       "metadata": {
-        "description": "Contains Azure Cosmos DB Conversations Container."
+        "description": "Contains Azure Cosmos DB conversations container name."
       },
       "value": "conversations"
     },
-    "azureCosmosDbDatabase": {
+    "AZURE_COSMOSDB_DATABASE": {
       "type": "string",
       "metadata": {
-        "description": "Contains Azure Cosmos DB Database."
+        "description": "Contains Azure Cosmos DB database name."
       },
       "value": "db_conversation_history"
     },
-    "azureCOSMOSDB_ENABLE_FEEDBACK": {
+    "AZURE_COSMOSDB_ENABLE_FEEDBACK": {
       "type": "string",
       "metadata": {
-        "description": "Contains Cosmos DB Enable Feedback."
+        "description": "Contains Azure Cosmos DB feedback enablement setting."
       },
       "value": "True"
     },
-    "azureOpenaiDeploymentModel": {
+    "AZURE_OPENAI_DEPLOYMENT_MODEL": {
       "type": "string",
       "metadata": {
-        "description": "Contains OpenAI Deployment Model."
+        "description": "Contains Azure OpenAI deployment model name."
       },
       "value": "[parameters('gptModelName')]"
     },
-    "azureOpenaiDeploymentModelCapacity": {
+    "AZURE_OPENAI_DEPLOYMENT_MODEL_CAPACITY": {
       "type": "int",
       "metadata": {
-        "description": "Contains OpenAI Deployment Capacity."
+        "description": "Contains Azure OpenAI deployment model capacity."
       },
       "value": "[parameters('gptDeploymentCapacity')]"
     },
-    "azureOpenaiENDPOINT": {
+    "AZURE_OPENAI_ENDPOINT": {
       "type": "string",
       "metadata": {
-        "description": "Contains OpenAI Endpoint."
+        "description": "Contains Azure OpenAI endpoint URL."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiServicesTarget.value]"
     },
-    "azureOpenaiModelDeploymentType": {
+    "AZURE_OPENAI_MODEL_DEPLOYMENT_TYPE": {
       "type": "string",
       "metadata": {
-        "description": "Contains OpenAI Model Deployment Type."
+        "description": "Contains Azure OpenAI model deployment type."
       },
       "value": "[parameters('deploymentType')]"
     },
-    "azureOpenaiEmbeddingModel": {
+    "AZURE_OPENAI_EMBEDDING_MODEL": {
       "type": "string",
       "metadata": {
-        "description": "Contains OpenAI Embedding Model."
+        "description": "Contains Azure OpenAI embedding model name."
       },
       "value": "[parameters('embeddingModel')]"
     },
-    "azureOpenaiEmbeddingModelCapacity": {
+    "AZURE_OPENAI_EMBEDDING_MODEL_CAPACITY": {
       "type": "int",
       "metadata": {
-        "description": "Contains OpenAI Embedding Model Capacity."
+        "description": "Contains Azure OpenAI embedding model capacity."
       },
       "value": "[parameters('embeddingDeploymentCapacity')]"
     },
-    "azureOpenaiApiVersion": {
+    "AZURE_OPENAI_API_VERSION": {
       "type": "string",
       "metadata": {
-        "description": "Contains OpenAI API Version."
+        "description": "Contains Azure OpenAI API version."
       },
       "value": "[parameters('azureOpenAIApiVersion')]"
     },
-    "azureOenaiResource": {
+    "AZURE_OPENAI_RESOURCE": {
       "type": "string",
       "metadata": {
-        "description": "Contains OpenAI Resource."
+        "description": "Contains Azure OpenAI resource name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiServicesName.value]"
     },
-    "reactAppLayoutConfig": {
+    "REACT_APP_LAYOUT_CONFIG": {
       "type": "string",
       "metadata": {
-        "description": "Contains React App Layout Config."
+        "description": "Contains React app layout configuration."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_backend_docker'), '2022-09-01').outputs.reactAppLayoutConfig.value]"
     },
-    "sqlDatabase": {
+    "SQLDB_DATABASE": {
       "type": "string",
       "metadata": {
-        "description": "Contains SQL Database."
+        "description": "Contains SQL database name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_sql_db'), '2022-09-01').outputs.sqlDbName.value]"
     },
-    "sqlServer": {
+    "SQLDB_SERVER": {
       "type": "string",
       "metadata": {
-        "description": "Contains SQL DB Server."
+        "description": "Contains SQL server name."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_sql_db'), '2022-09-01').outputs.sqlServerName.value]"
     },
-    "sqlUserMid": {
+    "SQLDB_USER_MID": {
       "type": "string",
       "metadata": {
-        "description": "Contains SQL DB User MID."
+        "description": "Contains SQL database user managed identity client ID."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_managed_identity'), '2022-09-01').outputs.managedIdentityBackendAppOutput.value.clientId]"
     },
-    "useAiProjectClient": {
+    "USE_AI_PROJECT_CLIENT": {
       "type": "string",
       "metadata": {
-        "description": "Contains Use AI Project Client."
+        "description": "Contains AI project client usage setting."
       },
       "value": "False"
     },
-    "useChatHistoryEnabled": {
+    "USE_CHAT_HISTORY_ENABLED": {
       "type": "string",
       "metadata": {
-        "description": "To specify whether to Enable or Disable chat history."
+        "description": "Contains chat history enablement setting."
       },
       "value": "True"
     },
-    "displayChartDefault": {
+    "DISPLAY_CHART_DEFAULT": {
       "type": "string",
       "metadata": {
-        "description": "To specify whether to Enable or Disable Display Chart."
+        "description": "Contains default chart display setting."
       },
       "value": "False"
     },
-    "azureAiAgentEndpoint": {
+    "AZURE_AI_AGENT_ENDPOINT": {
       "type": "string",
       "metadata": {
-        "description": "Contains AI Agent Endpoint."
+        "description": "Contains Azure AI Agent endpoint URL."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.projectEndpoint.value]"
     },
-    "azureAiAgentModelDeploymentName": {
+    "AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains Azure AI Agent Model Deployment Name."
+        "description": "Contains Azure AI Agent model deployment name."
       },
       "value": "[parameters('gptModelName')]"
     },
-    "acrName": {
+    "ACR_NAME": {
       "type": "string",
       "metadata": {
-        "description": "Contains ACR Name."
+        "description": "Contains Azure Container Registry name."
       },
       "value": "[variables('acrName')]"
     },
-    "azureEnvImageTag": {
+    "AZURE_ENV_IMAGETAG": {
       "type": "string",
       "metadata": {
-        "description": "Contains Azure Environment Image Tag."
+        "description": "Contains Azure environment image tag."
       },
       "value": "[parameters('imageTag')]"
     },
-    "azureExistingAiProjectResourceId": {
+    "AZURE_EXISTING_AI_PROJECT_RESOURCE_ID": {
       "type": "string",
       "metadata": {
-        "description": "Contains Existing AI Project Resource ID."
+        "description": "Contains existing AI project resource ID."
       },
       "value": "[parameters('azureExistingAIProjectResourceId')]"
     },
-    "applicationinsightsConnectionString": {
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": {
       "type": "string",
       "metadata": {
-        "description": "Contains App Insights Connection String."
+        "description": "Contains Application Insights connection string."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
     },
-    "apiAppUrl": {
+    "API_APP_URL": {
       "type": "string",
       "metadata": {
-        "description": "Contains API App URL."
+        "description": "Contains API application URL."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_backend_docker'), '2022-09-01').outputs.appUrl.value]"
     },
-    "webAppUrl": {
+    "WEB_APP_URL": {
       "type": "string",
       "metadata": {
-        "description": "Contains Web App URL."
+        "description": "Contains web application URL."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_frontend_docker'), '2022-09-01').outputs.appUrl.value]"
     }

--- a/src/start.cmd
+++ b/src/start.cmd
@@ -115,7 +115,7 @@ if exist "%API_ENV_FILE%" (
 REM Parse required variables for role assignments from the appropriate env file
 echo Reading environment variables for role assignments from: %ENV_FILE_FOR_ROLES%
 for /f "tokens=1,* delims==" %%A in ('type "%ENV_FILE_FOR_ROLES%"') do (
-    if "%%A"=="AZURE_RESOURCE_GROUP" set AZURE_RESOURCE_GROUP=%%~B
+    if "%%A"=="RESOURCE_GROUP_NAME" set AZURE_RESOURCE_GROUP=%%~B
     if "%%A"=="AZURE_COSMOSDB_ACCOUNT" set AZURE_COSMOSDB_ACCOUNT=%%~B
     if "%%A"=="AZURE_AI_FOUNDRY_NAME" set "AI_FOUNDRY_NAME=%%~B"
     if "%%A"=="AZURE_AI_SEARCH_NAME" set "SEARCH_SERVICE_NAME=%%~B"

--- a/src/start.sh
+++ b/src/start.sh
@@ -75,7 +75,7 @@ setup_environment() {
             value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed 's/^"\(.*\)"$/\1/')
             
             case "$key" in
-                AZURE_RESOURCE_GROUP) AZURE_RESOURCE_GROUP="$value" ;;
+                RESOURCE_GROUP_NAME) AZURE_RESOURCE_GROUP="$value" ;;
                 AZURE_COSMOSDB_ACCOUNT) AZURE_COSMOSDB_ACCOUNT="$value" ;;
                 AZURE_AI_FOUNDRY_NAME) AI_FOUNDRY_NAME="$value" ;;
                 AZURE_AI_SEARCH_NAME) SEARCH_SERVICE_NAME="$value" ;;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces significant improvements to the Azure infrastructure deployment scripts, focusing on standardizing parameter names, supporting resource tagging, and enhancing output variables for better integration and management. The changes primarily update the Bicep templates and deployment workflows to align with best practices, improve maintainability, and provide more flexibility for resource configuration.

**Key changes include:**

### Standardization and Parameterization

- Standardized parameter names across Bicep modules (e.g., `solutionName`, `hostingPlanName`, `websiteName`) and added descriptions to improve clarity and consistency in `infra/deploy_ai_foundry.bicep`, `infra/deploy_app_service.bicep`, and related files. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R2-R57) [[2]](diffhunk://#diff-37c8b5694d17291d641a19fb8a562e30642066b4bf8b8657f2636f50567cf4ebL12-R105) [[3]](diffhunk://#diff-85f6bac0ba41825094723b2a6a0963c6b562b081d5d06e93b0901af0c0902c7fR1-R21)
- Updated the deployment workflow (`.github/workflows/deploy.yml`) to use `solutionName` instead of `environmentName` for consistency with Bicep modules.

### Resource Tagging Support

- Introduced a `tags` parameter (with default empty object) to multiple Bicep files and ensured all major Azure resources (e.g., Log Analytics, Application Insights, Cognitive Services, Key Vault secrets, Search services) propagate this `tags` object, enabling consistent resource tagging for management and cost tracking. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L94-R131) [[2]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R144) [[3]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R173) [[4]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R187) [[5]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R206) [[6]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R233) [[7]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R262) [[8]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R280) [[9]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R342) [[10]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R352) [[11]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R361) [[12]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R372) [[13]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R381) [[14]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R390) [[15]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R399) [[16]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R408) [[17]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R419) [[18]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R430) [[19]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R439) [[20]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R448) [[21]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R457) [[22]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R466-R521) [[23]](diffhunk://#diff-85f6bac0ba41825094723b2a6a0963c6b562b081d5d06e93b0901af0c0902c7fR1-R21)

### Output Enhancements

- Added numerous output variables to `infra/deploy_ai_foundry.bicep` for key resource names, IDs, endpoints, and connection strings, making it easier to integrate deployed resources with downstream systems or modules.

### Naming Conventions

- Replaced dynamic abbreviations with fixed resource name prefixes (e.g., `aif-`, `appi-`, `kv-`, `srch-`, `log-`) for resource names, improving predictability and reducing dependency on external abbreviation files.

### Miscellaneous Improvements

- Added or updated parameters in `infra/deploy_app_service.bicep` to support additional configuration options such as API versions, enabling/disabling chat history, and specifying AI resource/project details.

These changes collectively improve the maintainability, clarity, and operational flexibility of the Azure deployment process.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.


## Other Information
<!-- Add any other helpful information that may be needed here.. -->