### PR TITLE
fix: remove unused files from setup_env.sh

### DIFF
--- a/.devcontainer/setup_env.sh
+++ b/.devcontainer/setup_env.sh
@@ -7,5 +7,3 @@ git pull
 sudo chmod +x ./infra/scripts/checkquota_km.sh
 sudo chmod +x ./infra/scripts/quota_check_params.sh
 sudo chmod +x ./infra/scripts/run_process_data_scripts.sh
-sudo chmod +x ./infra/scripts/docker-build.sh
-sudo chmod +x ./infra/scripts/docker-build.ps1


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the `.devcontainer/setup_env.sh` script by removing commands that set executable permissions for two Docker build scripts. This change likely reflects that these scripts are no longer needed or have been relocated.

* Removed `chmod +x` commands for `docker-build.sh` and `docker-build.ps1` in `.devcontainer/setup_env.sh`, indicating these scripts are no longer part of the setup process.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
