### PR TITLE
chore: Bicep changes to add CreatedBy tag

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -106,7 +106,7 @@ var solutionSuffix = toLower(trim(replace(
   '*',
   ''
 )))
-
+var deployerInfo = deployer()
 // ========== Resource Group Tag ========== //
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
@@ -114,6 +114,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
     tags: {
       ... tags
       TemplateName: 'KM Generic'
+      CreatedBy: split(deployerInfo.userPrincipalName, '@')[0] 
     }
   }
 }


### PR DESCRIPTION
## Purpose
This pull request makes a minor enhancement to the resource group tagging in the `infra/main.bicep` file. The main change is the addition of a new tag to capture the username of the deployer who initiated the deployment.

Resource group tagging improvements:

* Added a `CreatedBy` tag to resource group tags, which stores the deployer's username extracted from `deployerInfo.userPrincipalName`.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

