### PR TITLE
fix: Set Cosmos DB deployment location to the primary region

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -187,7 +187,7 @@ module cosmosDBModule 'deploy_cosmos_db.bicep' = {
   name: 'deploy_cosmos_db'
   params: {
     accountName: 'cosmos-${solutionSuffix}'
-    solutionLocation: secondaryLocation
+    solutionLocation: solutionLocation
     keyVaultName: kvault.outputs.keyvaultName
     tags : tags
   }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "7263803858241829495"
+      "templateHash": "10686282742508674905"
     }
   },
   "parameters": {
@@ -166,6 +166,13 @@
       "metadata": {
         "description": "Optional. A unique text value for the solution. This is used to ensure resource names are unique for global resources. Defaults to a 5-character substring of the unique string generated from the subscription ID, resource group name, and solution name."
       }
+    },
+    "createdBy": {
+      "type": "string",
+      "defaultValue": "[if(empty(deployer().userPrincipalName), '', split(deployer().userPrincipalName, '@')[0])]",
+      "metadata": {
+        "description": "Optional created by user name"
+      }
     }
   },
   "variables": {
@@ -180,7 +187,7 @@
       "apiVersion": "2021-04-01",
       "name": "default",
       "properties": {
-        "tags": "[shallowMerge(createArray(parameters('tags'), createObject('TemplateName', 'KM Generic')))]"
+        "tags": "[shallowMerge(createArray(parameters('tags'), createObject('TemplateName', 'KM Generic', 'CreatedBy', parameters('createdBy'))))]"
       }
     },
     {
@@ -2258,7 +2265,7 @@
             "value": "[format('cosmos-{0}', variables('solutionSuffix'))]"
           },
           "solutionLocation": {
-            "value": "[parameters('secondaryLocation')]"
+            "value": "[variables('solutionLocation')]"
           },
           "keyVaultName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_keyvault'), '2022-09-01').outputs.keyvaultName.value]"


### PR DESCRIPTION
## Purpose
This pull request updates the Cosmos DB deployment infrastructure to improve parameter handling and resource tagging. The main changes ensure that the correct location variable is used, add a new `createdBy` parameter for better traceability, and update resource tags to include the creator information.

**Parameter and variable improvements:**

* Updated the `solutionLocation` parameter in the Cosmos DB deployment to use the correct variable, ensuring consistency across Bicep and JSON templates (`infra/main.bicep`, `infra/main.json`). [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L190-R190) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2261-R2268)
* Added a new `createdBy` parameter that automatically captures the deployer's username for improved auditability (`infra/main.json`).

**Tagging enhancements:**

* Modified resource tags to include both the template name and the new `CreatedBy` field, improving traceability of deployed resources (`infra/main.json`).

**Template metadata updates:**

* Updated the Bicep-generated template hash to reflect changes in the deployment template (`infra/main.json`).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.