### PR TITLE
fix: Set Cosmos DB deployment location to the primary region

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -112,11 +112,18 @@ param createdBy string = empty(deployer().userPrincipalName) ? '' : split(deploy
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
   properties: {
-    tags: {
-      ... tags
-      TemplateName: 'KM Generic'
-      CreatedBy: createdBy
-    }
+    tags: union(
+      reference(
+        resourceGroup().id, 
+        '2021-04-01', 
+        'Full'
+      ).tags ?? {},
+      {
+        TemplateName: 'KM Generic'
+        CreatedBy: createdBy
+      },
+      tags
+    )
   }
 }
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "10686282742508674905"
+      "templateHash": "4854945365103887323"
     }
   },
   "parameters": {
@@ -187,7 +187,7 @@
       "apiVersion": "2021-04-01",
       "name": "default",
       "properties": {
-        "tags": "[shallowMerge(createArray(parameters('tags'), createObject('TemplateName', 'KM Generic', 'CreatedBy', parameters('createdBy'))))]"
+        "tags": "[union(coalesce(reference(resourceGroup().id, '2021-04-01', 'Full').tags, createObject()), createObject('TemplateName', 'KM Generic', 'CreatedBy', parameters('createdBy')), parameters('tags'))]"
       }
     },
     {


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure deployment templates to improve resource tagging and parameter handling, particularly for Cosmos DB deployments. The main changes include adding a `createdBy` parameter for tracking deployments, correcting parameter references for solution location, and enhancing resource tags to include deployment metadata.

**Parameter and Tagging Improvements:**

* Added a new `createdBy` parameter in `infra/main.json` to capture the deploying user's name, with logic to extract the username from the principal name.
* Updated Cosmos DB resource tags to include the `CreatedBy` value, allowing for better tracking of resource ownership.

**Parameter Reference Corrections:**

* Changed the `solutionLocation` parameter in the Cosmos DB module deployment in `infra/main.bicep` to use the correct variable, ensuring deployments use the intended location.
* Updated the `solutionLocation` value in `infra/main.json` to reference the correct variable instead of the parameter, aligning with the Bicep module change.

**Template Metadata:**

* Updated the template hash in `infra/main.json` to reflect the changes in the template structure.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.