### PR TITLE
fix: Update tag handling to include existing tags in resource g…

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -112,11 +112,18 @@ param createdBy string = empty(deployer().userPrincipalName) ? '' : split(deploy
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
   properties: {
-    tags: {
-      ... tags
-      TemplateName: 'KM Generic'
-      CreatedBy: createdBy
-    }
+    tags: union(
+      reference(
+        resourceGroup().id, 
+        '2021-04-01', 
+        'Full'
+      ).tags ?? {},
+      {
+        TemplateName: 'KM Generic'
+        CreatedBy: createdBy
+      },
+      tags
+    )
   }
 }
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "10686282742508674905"
+      "templateHash": "4854945365103887323"
     }
   },
   "parameters": {
@@ -187,7 +187,7 @@
       "apiVersion": "2021-04-01",
       "name": "default",
       "properties": {
-        "tags": "[shallowMerge(createArray(parameters('tags'), createObject('TemplateName', 'KM Generic', 'CreatedBy', parameters('createdBy'))))]"
+        "tags": "[union(coalesce(reference(resourceGroup().id, '2021-04-01', 'Full').tags, createObject()), createObject('TemplateName', 'KM Generic', 'CreatedBy', parameters('createdBy')), parameters('tags'))]"
       }
     },
     {


### PR DESCRIPTION
## Purpose

This pull request updates the resource group tagging logic in the infrastructure templates to ensure that existing resource group tags are preserved and merged with new tags defined in the deployment. The main change is the use of the `union` function to combine existing tags, template metadata, and custom tags, improving tag management and consistency.

**Tag management improvements:**

* Updated the `resourceGroupTags` resource in `infra/main.bicep` to use the `union` function, merging existing resource group tags, template metadata (`TemplateName` and `CreatedBy`), and custom tags provided during deployment. This ensures all relevant tags are retained and avoids overwriting existing tags.
* Modified the `tags` property in `infra/main.json` to use the `union` and `coalesce` functions for merging tags, aligning the JSON template logic with the new Bicep implementation.

**Template metadata update:**

* Updated the `templateHash` value in `infra/main.json` to reflect changes in the template structure.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.