### PR TITLE
fix: Update Azure Developer CLI version to 1.18.0 in documentation and configuration files

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -7,7 +7,7 @@ environment:
 name: conversation-knowledge-mining
 
 requiredVersions:
-  azd: ">= 1.15.0"
+  azd: ">= 1.18.0"
 
 metadata:
   template: conversation-knowledge-mining@1.0

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -119,7 +119,7 @@ If you're not using one of the above options for opening the project, then you'l
 
 1. Make sure the following tools are installed:
     - [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.5) <small>(v7.0+)</small> - available for Windows, macOS, and Linux.
-    - [Azure Developer CLI (azd)](https://aka.ms/install-azd) <small>(v1.15.0+)</small> - version
+    - [Azure Developer CLI (azd)](https://aka.ms/install-azd) <small>(v1.18.0+)</small> - version
     - [Python 3.9+](https://www.python.org/downloads/)
     - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
     - [Git](https://git-scm.com/downloads)

--- a/documents/LocalDebuggingSetup.md
+++ b/documents/LocalDebuggingSetup.md
@@ -15,7 +15,7 @@ Install these tools before you start:
 - [PowerShell 7.0+](https://github.com/PowerShell/PowerShell#get-powershell).
 - [Node.js (LTS)](https://nodejs.org/en).
 - [Git](https://git-scm.com/downloads).
-- [Azure Developer CLI (azd) v1.15.0+](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
+- [Azure Developer CLI (azd) v1.18.0+](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 - [Microsoft ODBC Driver 17](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16) for SQL Server.
 
 


### PR DESCRIPTION
## Purpose
This pull request updates the minimum required version of the Azure Developer CLI (`azd`) from v1.15.0 to v1.18.0 across configuration and documentation files to ensure compatibility with newer features and bug fixes.

Dependency version update:

* Updated the `azd` required version to ">= 1.18.0" in the `azure.yaml` configuration file.

Documentation updates:

* Changed the listed minimum version of `azd` to v1.18.0 in the "DeploymentGuide.md" and "LocalDebuggingSetup.md" documentation to match the new requirement. [[1]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L122-R122) [[2]](diffhunk://#diff-2fcc58fb44a482272f1c97fc071159646d524bdaaed6bba066f2b0c6a74fbfdaL18-R18)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify the deployment (azd up)
