### PR TITLE
fix: Custom data processing - Exclude SQL user-assigned identities from identity retrieval query

### DIFF
--- a/infra/scripts/run_process_data_scripts.sh
+++ b/infra/scripts/run_process_data_scripts.sh
@@ -25,7 +25,7 @@ echo "Fetching Key Vault and Managed Identity from resource group: $resourceGrou
 keyVaultName=$(az keyvault list --resource-group "$resourceGroupName" --query "[0].name" -o tsv)
 
 # === Retrieve the ID of the first user-assigned identity with name starting with 'id-' ===
-managedIdentityResourceId=$(az identity list --resource-group "$resourceGroupName" --query "[?starts_with(name, 'id-')].id | [0]" -o tsv)
+managedIdentityResourceId=$(az identity list --resource-group "$resourceGroupName" --query "[?starts_with(name, 'id-') && !starts_with(name, 'id-sql-')].id | [0]" -o tsv)
 
 # === Normalize managedIdentityResourceId (necessary for compatibility in Git Bash on Windows) ===
 managedIdentityResourceId=$(echo "$managedIdentityResourceId" | sed -E 's|.*(/subscriptions/)|\1|')
@@ -34,7 +34,7 @@ managedIdentityResourceId=$(echo "$managedIdentityResourceId" | sed -E 's|.*(/su
 sqlServerLocation=$(az sql server list --resource-group "$resourceGroupName" --query "[0].location" -o tsv)
 
 # === Retrieve the principal ID of the first user-assigned identity with name starting with 'id-' ===
-managedIdentityClientId=$(az identity list --resource-group "$resourceGroupName" --query "[?starts_with(name, 'id-')].clientId | [0]" -o tsv)
+managedIdentityClientId=$(az identity list --resource-group "$resourceGroupName" --query "[?starts_with(name, 'id-') && !starts_with(name, 'id-sql-')].clientId | [0]" -o tsv)
 
 # === Validate that all required resources were found ===
 if [[ -z "$keyVaultName" || -z "$sqlServerLocation" || -z "$managedIdentityResourceId" || ! "$managedIdentityResourceId" =~ ^/subscriptions/ ]]; then


### PR DESCRIPTION
## Purpose
This pull request makes a targeted improvement to the way managed identities are selected in the `infra/scripts/run_process_data_scripts.sh` script. Specifically, it refines the filtering logic to exclude identities with names starting with `id-sql-`, ensuring only the intended identities are used.

Identity selection logic update:

* Updated the queries for both `managedIdentityResourceId` and `managedIdentityClientId` to exclude user-assigned identities whose names start with `id-sql-`, preventing accidental selection of SQL-related managed identities. [[1]](diffhunk://#diff-16bab50f8dd1b70d78f1df0136ae064e15a39829379e51e317f28f7138ca4897L28-R28) [[2]](diffhunk://#diff-16bab50f8dd1b70d78f1df0136ae064e15a39829379e51e317f28f7138ca4897L37-R37)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify custom data processing.
