### PR TITLE
fix: nonWAF to WAF migration fix - Added location param to name to differentiate script name

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -221,7 +221,6 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
         TemplateName: 'KM-Generic'
         Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
         CreatedBy: createdBy
-        SecurityControl: 'Ignore'
       },
       tags
     )


### PR DESCRIPTION
## Purpose
This pull request updates the `infra/main.bicep` deployment scripts to improve naming consistency and add a new metadata tag for resource tracking. The main changes involve dynamically naming deployment script resources based on networking configuration and location, and adding a `SecurityControl` tag.

Deployment script naming improvements:

* The `name` parameter for the `uploadFiles`, `createIndex`, and `createSqlUserAndRole` deployment script modules now appends either the main or secondary location depending on whether private networking is enabled. This helps differentiate deployments in different environments. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1322-R1323) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1351-R1352) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1385-R1386)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.


