### PR TITLE
fix:  updated the value for the `AI_FOUNDRY_RESOURCE_ID` output to be AI Foundry Resource Id instead of AI Foundry Project Resource Id

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1515,8 +1515,8 @@ output STORAGE_ACCOUNT_NAME string = storageAccount.outputs.name
 @description('Name of the Storage Container.')
 output STORAGE_CONTAINER_NAME string = 'data'
 
-@description('Resource ID of the AI Foundry Project.')
-output AI_FOUNDRY_RESOURCE_ID string = !empty(existingAiFoundryAiProjectResourceId) ? existingAiFoundryAiProjectResourceId : aiFoundryAiServices.outputs.resourceId
+@description('Resource ID of the AI Foundry.')
+output AI_FOUNDRY_RESOURCE_ID string = aiFoundryAiServices.outputs.resourceId
 
 @description('Resource ID of the Content Understanding AI Foundry.')
 output CU_FOUNDRY_RESOURCE_ID string = cognitiveServicesCu.outputs.resourceId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1303,7 +1303,7 @@ module webSiteBackend 'modules/web-sites.bicep' = {
           AGENT_NAME_CONVERSATION: ''
           AGENT_NAME_TITLE: ''
           API_APP_NAME: 'api-${solutionSuffix}'
-          AI_FOUNDRY_RESOURCE_ID: !empty(existingAiFoundryAiProjectResourceId) ? existingAiFoundryAiProjectResourceId : aiFoundryAiServices.outputs.resourceId
+          AI_FOUNDRY_RESOURCE_ID: aiFoundryAiServices.outputs.resourceId
           AZURE_OPENAI_DEPLOYMENT_MODEL: gptModelName
           AZURE_OPENAI_ENDPOINT: !empty(existingOpenAIEndpoint) ? existingOpenAIEndpoint : 'https://${aiFoundryAiServices.outputs.name}.openai.azure.com/'
           AZURE_OPENAI_API_VERSION: azureOpenAIApiVersion

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "5174764827592423272"
+      "templateHash": "11577788299786255320"
     }
   },
   "parameters": {
@@ -30052,8 +30052,8 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "logAnalyticsWorkspace",
         "userAssignedIdentity",
@@ -40364,9 +40364,9 @@
         }
       },
       "dependsOn": [
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageDfs)]",
         "userAssignedIdentity",
         "virtualNetwork"
@@ -58326,9 +58326,9 @@
     "AI_FOUNDRY_RESOURCE_ID": {
       "type": "string",
       "metadata": {
-        "description": "Resource ID of the AI Foundry Project."
+        "description": "Resource ID of the AI Foundry."
       },
-      "value": "[if(not(empty(parameters('existingAiFoundryAiProjectResourceId'))), parameters('existingAiFoundryAiProjectResourceId'), reference('aiFoundryAiServices').outputs.resourceId.value)]"
+      "value": "[reference('aiFoundryAiServices').outputs.resourceId.value]"
     },
     "CU_FOUNDRY_RESOURCE_ID": {
       "type": "string",

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "11577788299786255320"
+      "templateHash": "4561763394589490968"
     }
   },
   "parameters": {
@@ -30052,9 +30052,9 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "logAnalyticsWorkspace",
         "userAssignedIdentity",
         "virtualNetwork"
@@ -54139,7 +54139,7 @@
                   "AGENT_NAME_CONVERSATION": "",
                   "AGENT_NAME_TITLE": "",
                   "API_APP_NAME": "[format('api-{0}', variables('solutionSuffix'))]",
-                  "AI_FOUNDRY_RESOURCE_ID": "[if(not(empty(parameters('existingAiFoundryAiProjectResourceId'))), parameters('existingAiFoundryAiProjectResourceId'), reference('aiFoundryAiServices').outputs.resourceId.value)]",
+                  "AI_FOUNDRY_RESOURCE_ID": "[reference('aiFoundryAiServices').outputs.resourceId.value]",
                   "AZURE_OPENAI_DEPLOYMENT_MODEL": "[parameters('gptModelName')]",
                   "AZURE_OPENAI_ENDPOINT": "[if(not(empty(variables('existingOpenAIEndpoint'))), variables('existingOpenAIEndpoint'), format('https://{0}.openai.azure.com/', reference('aiFoundryAiServices').outputs.name.value))]",
                   "AZURE_OPENAI_API_VERSION": "[parameters('azureOpenAIApiVersion')]",

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1522,8 +1522,8 @@ output STORAGE_ACCOUNT_NAME string = storageAccount.outputs.name
 @description('Name of the Storage Container.')
 output STORAGE_CONTAINER_NAME string = 'data'
 
-@description('Resource ID of the AI Foundry Project.')
-output AI_FOUNDRY_RESOURCE_ID string = !empty(existingAiFoundryAiProjectResourceId) ? existingAiFoundryAiProjectResourceId : aiFoundryAiServices.outputs.resourceId
+@description('Resource ID of the AI Foundry.')
+output AI_FOUNDRY_RESOURCE_ID string = aiFoundryAiServices.outputs.resourceId
 
 @description('Resource ID of the Content Understanding AI Foundry.')
 output CU_FOUNDRY_RESOURCE_ID string = cognitiveServicesCu.outputs.resourceId


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request simplifies the handling of the AI Foundry resource ID in the infrastructure templates by removing conditional logic that previously allowed for an existing AI Foundry project resource ID to be used. Now, the resource ID is always taken from the newly provisioned AI Foundry service outputs. Additionally, minor updates were made to output descriptions and dependency ordering in the generated JSON files.

Resource ID handling simplification:

* Changed the assignment of `AI_FOUNDRY_RESOURCE_ID` in `main.bicep`, `main_custom.bicep`, and the generated `main.json` so it always uses `aiFoundryAiServices.outputs.resourceId`, removing the conditional fallback to `existingAiFoundryAiProjectResourceId`. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1306-R1306) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1518-R1519) [[3]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L1525-R1526) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L54142-R54142) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L58329-R58331)
* Updated the description for the `AI_FOUNDRY_RESOURCE_ID` output to refer to "AI Foundry" instead of "AI Foundry Project" for clarity and consistency. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1518-R1519) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L1525-R1526) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L58329-R58331)

Dependency and metadata updates:

* Adjusted dependency ordering in `main.json` for private DNS zones to ensure proper deployment sequencing. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L30056-R30057) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R40367-L40369)
* Updated the `templateHash` in `main.json` to reflect changes in the template.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

