### PR TITLE
chore: add minimum bicep version >= 0.33.0 to azure_custom.yaml

### DIFF
--- a/azure_custom.yaml
+++ b/azure_custom.yaml
@@ -2,6 +2,7 @@ name: conversation-knowledge-mining
 
 requiredVersions:
   azd: ">= 1.18.0 != 1.23.9"
+  bicep: ">= 0.33.0"
 
 metadata:
   template: conversation-knowledge-mining@1.0


### PR DESCRIPTION
## Summary
Adds bicep >= 0.33.0 to requiredVersions in azure_custom.yaml to enforce minimum Bicep CLI version.

## Changes
- Updated azure_custom.yaml to include bicep: >= 0.33.0 under requiredVersions