### PR TITLE
feat: Add pytest coverage comment to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 
 jobs:
   #   frontend_tests:
@@ -106,7 +107,19 @@ jobs:
       - name: Run Backend Tests with Coverage
         if: env.skip_backend_tests == 'false'
         run: |
-          pytest --cov=. --cov-report=term-missing --cov-report=xml ./src/tests/api
+          pytest --cov=. --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml ./src/tests/api
+
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          env.skip_backend_tests == 'false'
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: pytest.xml
+          report-only-changed-files: true
 
       - name: Skip Backend Tests
         if: env.skip_backend_tests == 'true'


### PR DESCRIPTION
Add MishaKav/pytest-coverage-comment action to post code coverage summary as a PR comment. Changes include:
- Add pull-requests: write permission
- Add --junitxml=pytest.xml flag for test summary
- Add coverage comment step with per-file breakdown

## Purpose

This pull request updates the GitHub Actions workflow to enhance test reporting and permissions. The most important changes are:

**Workflow Permissions:**
* Added `pull-requests: write` permission to the workflow, allowing the workflow to post comments on pull requests.

**Test Reporting and Automation:**
* Modified the backend test step to generate a `pytest.xml` file by adding the `--junitxml=pytest.xml` flag to the `pytest` command, enabling richer test result reporting.
* Added a new step using the `MishaKav/pytest-coverage-comment` GitHub Action to automatically post a coverage summary as a comment on pull requests, but only for non-fork PRs where backend tests are not skipped.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

