### PR TITLE
fix: dev to main - DevContainer Tooling Update and constants.py API Cleanup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,11 @@
     "forwardPorts": [50505],
     "features": {
         "ghcr.io/azure/azure-dev/azd:latest": {},
-        "ghcr.io/devcontainers/features/azure-cli:1": {},
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "installBicep": true,
+            "version": "latest",
+            "bicepVersion": "latest"
+        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/jlaundry/devcontainer-features/mssql-odbc-driver:1": {
 			"version": "18"

--- a/tests/e2e-test/config/constants.py
+++ b/tests/e2e-test/config/constants.py
@@ -36,3 +36,6 @@ with open(ithelpdesk_json_file_path, 'r') as file:
 # Backward compatibility - keep 'questions' as alias for telecom_questions
 questions = telecom_questions
 
+# Public exports
+__all__ = ['URL', 'API_URL', 'telecom_questions', 'ithelpdesk_questions', 'questions']
+


### PR DESCRIPTION
## Purpose
This pull request contains a couple of targeted improvements to the development environment configuration and the test constants. The main changes are an enhancement to the Azure CLI feature in the devcontainer setup and the addition of explicit public exports in the test constants module.

Development environment improvements:
* Updated the Azure CLI feature configuration in `.devcontainer/devcontainer.json` to ensure Bicep is installed with the latest version, improving infrastructure-as-code support.

Test module enhancements:
* Added an `__all__` declaration in `tests/e2e-test/config/constants.py` to explicitly define the module's public API, making imports clearer and more maintainable.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.