### PR TITLE
fix: Enhance delete_all_conversations to handle transient connection error with a retry mechanism

### DIFF
--- a/src/api/api/history_routes.py
+++ b/src/api/api/history_routes.py
@@ -387,8 +387,22 @@ async def delete_all_conversations(request: Request):
         user_id = authenticated_user["user_principal_id"]
         logger.info("DELETE /history/delete_all called")
 
-        # Get all user conversations
+        # Get all user conversations.
+        # NOTE: After the web page sits idle for >10 minutes, the first call
+        # to Cosmos DB from this long-lived process can fail with a transient
+        # connection-reset / token-expiry error. `history_service.get_conversations`
+        # swallows that exception and returns []. Without the retry below,
+        # "Clear all chat history" would then 404 -> get masked to 500 even
+        # though chats actually exist. Single-conversation delete is unaffected
+        # because it does not pre-list conversations. Retry once before giving up.
         conversations = await history_service.get_conversations(user_id, offset=0, limit=None)
+        if not conversations:
+            logger.info(
+                "delete_all: initial get_conversations returned empty; "
+                "retrying once to recover from possible idle-connection failure"
+            )
+            conversations = await history_service.get_conversations(user_id, offset=0, limit=None)
+
         if not conversations:
             track_event_if_configured("DeleteAllConversationsNotFound", {
                 "user_id": user_id
@@ -413,6 +427,10 @@ async def delete_all_conversations(request: Request):
             status_code=200,
         )
 
+    except HTTPException:
+        # Let FastAPI translate HTTPException to its proper status code
+        # instead of masking it as a 500 below.
+        raise
     except Exception as e:
         logger.exception("Exception in /history/delete_all: %s", str(e))
         track_event_if_configured("AllConversationsDeleteError", {


### PR DESCRIPTION
## Purpose
This pull request improves the reliability and error handling of the `delete_all_conversations` endpoint in `history_routes.py`. The main focus is to address transient connection issues with Cosmos DB after idle periods and to ensure proper HTTP error propagation.

Error handling and reliability improvements:

* Added a retry mechanism for fetching user conversations in `delete_all_conversations` to handle transient connection failures after the web process has been idle, ensuring that a temporary Cosmos DB error does not result in a misleading 404 or 500 error when conversations actually exist.
* Updated exception handling to re-raise `HTTPException` so FastAPI can return the correct status code, rather than masking it as a 500 error, improving the accuracy of error responses.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

