### PR TITLE
refactor: rename get_async_azure_credential to build_async_azure_credential (address Copilot review on #915)

### DIFF
--- a/src/api/helpers/azure_credential_utils.py
+++ b/src/api/helpers/azure_credential_utils.py
@@ -41,11 +41,12 @@ def get_azure_credential(client_id=None):
         return ManagedIdentityCredential(client_id=client_id)
 
 
-def get_async_azure_credential(client_id=None):
+def build_async_azure_credential(client_id=None):
     """
-    Synchronously returns an async Azure credential suitable for async SDK clients
-    (e.g., azure.cosmos.aio.CosmosClient). Mirrors get_azure_credential_async but
-    is callable from sync code paths.
+    Synchronously builds an async Azure credential suitable for async SDK clients
+    (e.g., azure.cosmos.aio.CosmosClient). Use this from sync constructors that
+    need to hand an async-capable credential to an async client; use
+    get_azure_credential_async() instead from `async with` blocks.
     """
     if os.getenv("APP_ENV", "prod").lower() == 'dev':
         return AioAzureCliCredential()

--- a/src/api/services/history_service.py
+++ b/src/api/services/history_service.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException, status
 from azure.ai.projects.aio import AIProjectClient
 from common.config.config import Config
 from common.database.cosmosdb_service import CosmosConversationClient
-from helpers.azure_credential_utils import get_azure_credential_async, get_async_azure_credential
+from helpers.azure_credential_utils import get_azure_credential_async, build_async_azure_credential
 
 from agent_framework.azure import AzureAIProjectAgentProvider
 
@@ -46,7 +46,7 @@ class HistoryService:
 
             return CosmosConversationClient(
                 cosmosdb_endpoint=cosmos_endpoint,
-                credential=get_async_azure_credential(client_id=self.azure_client_id),
+                credential=build_async_azure_credential(client_id=self.azure_client_id),
                 database_name=self.azure_cosmosdb_database,
                 container_name=self.azure_cosmosdb_conversations_container,
                 enable_message_feedback=self.azure_cosmosdb_enable_feedback,


### PR DESCRIPTION
## Purpose
* Addresses the [GitHub Copilot review comment](https://github.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/pull/914#discussion) raised on PR #915 (Bug 43424 fix), which is now blocking the `dev` -> `main` merge in PR #914.
* PR #915 introduced a new sync helper named `get_async_azure_credential` alongside the existing async helper `get_azure_credential_async`. The two names differ only by word order, which is easy to confuse at call sites — and `history_service.py` now imports both side-by-side.
* This PR renames the new helper to `build_async_azure_credential` so the sync-vs-async distinction is explicit at every call site (`build_` implies sync construction; `async` describes the returned credential type). No behavioral change.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

> The renamed function is internal to `src/api` and only referenced from `history_service.py`. No public API, no config, no infra change.

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

> Bug 43424 fix from PR #915 was previously validated end-to-end on validation RGs `rg-kmgenrf02` (australiaeast) and `rg-kmgenrf03` (japaneast) on the CSA-CTO-Engineering-Maintenance subscription using branch images `acrkmgenpsl02.azurecr.io/km-{api,app}:psl-fix`. Single-chat delete and bulk-delete after idle session both succeed without the prior 500. This PR is a pure rename on top of that validated fix.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

> Same validated deployment as PR #915 — no infrastructure or environment changes in this PR.

## What to Check
Verify that the following are valid
* `src/api/helpers/azure_credential_utils.py` — `get_async_azure_credential` is renamed to `build_async_azure_credential`; signature, branching on `APP_ENV`, and returned credential types are unchanged.
* `src/api/services/history_service.py` — import on line 8 and call site in `init_cosmosdb_client` (line 49) updated to the new name. `get_azure_credential_async` (the original async helper, used in the `async with` block on line 73) is left untouched.
* No call sites of the old name remain anywhere in the repo (verified via grep).
* `flake8 --config=.flake8 src/api` passes locally.

## Other Information

* Originating Copilot comment on the merged PR:
  > *"Two near-identical helpers now exist: `get_azure_credential_async` (async function returning an async credential) and the new `get_async_azure_credential` (sync function returning the same async credential types). The names differ only by word order, which is easy to confuse at call sites — note that `history_service.py` now imports both. Consider renaming the new function to something less ambiguous (e.g., `get_async_azure_credential_sync` or `build_async_azure_credential`) to make the sync-vs-async distinction obvious at the call site."*
* Chose `build_async_azure_credential` (one of Copilot's two suggestions) because `build_` is a common Python idiom for sync factory functions and reads more naturally than the `_sync` suffix variant.
* Diff size: 2 files, +7/-6 lines.
