### PR TITLE
refactor: Updated Foundry Roles name

### DIFF
--- a/documents/LocalDevelopmentSetup.md
+++ b/documents/LocalDevelopmentSetup.md
@@ -389,10 +389,10 @@ Write-Host $PRINCIPAL_ID
 #### Azure AI Foundry & OpenAI Access
 
 ```bash
-# Assign Azure AI User role
+# Assign Foundry User role
 az role assignment create \
   --assignee $PRINCIPAL_ID \
-  --role "Azure AI User" \
+  --role "Foundry User" \
   --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.MachineLearningServices/workspaces/<ai-foundry-name>"
 
 # Assign Cognitive Services OpenAI User role

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -729,12 +729,12 @@ module aiFoundryAiServices 'modules/ai-services.bicep' = {
     managedIdentities: { userAssignedResourceIds: [userAssignedIdentity!.outputs.resourceId] } //To create accounts or projects, you must enable a managed identity on your resource
     roleAssignments: [
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: userAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: backendUserAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "9558335949477141360"
+      "templateHash": "1762309424496235679"
     }
   },
   "parameters": {
@@ -396,7 +396,7 @@
     "sqlServerResourceName": "[format('sql-{0}', variables('solutionSuffix'))]",
     "sqlDbModuleName": "[format('sqldb-{0}', variables('solutionSuffix'))]",
     "webServerFarmResourceName": "[format('asp-{0}', variables('solutionSuffix'))]",
-    "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n    \"THREE_COLUMN\": {\r\n      \"DASHBOARD\": 50,\r\n      \"CHAT\": 33,\r\n      \"CHATHISTORY\": 17\r\n    },\r\n    \"TWO_COLUMN\": {\r\n      \"DASHBOARD_CHAT\": {\r\n        \"DASHBOARD\": 65,\r\n        \"CHAT\": 35\r\n      },\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 80,\r\n        \"CHATHISTORY\": 20\r\n      }\r\n    }\r\n  },\r\n  \"charts\": [\r\n    {\r\n      \"id\": \"SATISFIED\",\r\n      \"name\": \"Satisfied\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\r\n    },\r\n    {\r\n      \"id\": \"TOTAL_CALLS\",\r\n      \"name\": \"Total Calls\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME\",\r\n      \"name\": \"Average Handling Time\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"SENTIMENT\",\r\n      \"name\": \"Topics Overview\",\r\n      \"type\": \"donutchart\",\r\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\r\n      \"name\": \"Average Handling Time By Topic\",\r\n      \"type\": \"bar\",\r\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\r\n    },\r\n    {\r\n      \"id\": \"TOPICS\",\r\n      \"name\": \"Trending Topics\",\r\n      \"type\": \"table\",\r\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\r\n    },\r\n    {\r\n      \"id\": \"KEY_PHRASES\",\r\n      \"name\": \"Key Phrases\",\r\n      \"type\": \"wordcloud\",\r\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\r\n    }\r\n  ]\r\n}",
+    "reactAppLayoutConfig": "{\n  \"appConfig\": {\n    \"THREE_COLUMN\": {\n      \"DASHBOARD\": 50,\n      \"CHAT\": 33,\n      \"CHATHISTORY\": 17\n    },\n    \"TWO_COLUMN\": {\n      \"DASHBOARD_CHAT\": {\n        \"DASHBOARD\": 65,\n        \"CHAT\": 35\n      },\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 80,\n        \"CHATHISTORY\": 20\n      }\n    }\n  },\n  \"charts\": [\n    {\n      \"id\": \"SATISFIED\",\n      \"name\": \"Satisfied\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\n    },\n    {\n      \"id\": \"TOTAL_CALLS\",\n      \"name\": \"Total Calls\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME\",\n      \"name\": \"Average Handling Time\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\n    },\n    {\n      \"id\": \"SENTIMENT\",\n      \"name\": \"Topics Overview\",\n      \"type\": \"donutchart\",\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\n      \"name\": \"Average Handling Time By Topic\",\n      \"type\": \"bar\",\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\n    },\n    {\n      \"id\": \"TOPICS\",\n      \"name\": \"Trending Topics\",\n      \"type\": \"table\",\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\n    },\n    {\n      \"id\": \"KEY_PHRASES\",\n      \"name\": \"Key Phrases\",\n      \"type\": \"wordcloud\",\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\n    }\n  ]\n}",
     "backendWebSiteResourceName": "[format('api-{0}', variables('solutionSuffix'))]",
     "webSiteResourceName": "[format('app-{0}', variables('solutionSuffix'))]"
   },
@@ -29627,9 +29627,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "virtualNetwork"
       ]
     },
@@ -39943,10 +39943,10 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageDfs)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageDfs)]",
         "userAssignedIdentity",
         "virtualNetwork"
       ]

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -713,12 +713,12 @@ module aiFoundryAiServices 'modules/ai-services.bicep' = {
     managedIdentities: { userAssignedResourceIds: [userAssignedIdentity!.outputs.resourceId] } //To create accounts or projects, you must enable a managed identity on your resource
     roleAssignments: [
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: userAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: backendUserAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }

--- a/infra/scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/run_create_agents_scripts.sh
@@ -284,7 +284,7 @@ else
     exit 1
 fi
 
-# Check if the principal has Azure AI User role on the AI Foundry
+# Check if the principal has Foundry User role on the AI Foundry
 role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list \
   --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
   --scope "$aiFoundryResourceId" \
@@ -292,18 +292,18 @@ role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list \
   --query "[].roleDefinitionId" -o tsv)
 
 if [ -z "$role_assignment" ]; then
-    echo "✓ Assigning Azure AI User role for AI Foundry"
+    echo "✓ Assigning Foundry User role for AI Foundry"
     MSYS_NO_PATHCONV=1 az role assignment create \
       --assignee "$signed_user_id" \
       --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
       --scope "$aiFoundryResourceId" \
       --output none
     if [ $? -ne 0 ]; then
-        echo "✗ Failed to assign Azure AI User role for AI Foundry"
+        echo "✗ Failed to assign Foundry User role for AI Foundry"
         exit 1
     fi
 else
-    echo "✓ Principal already has the Azure AI User role"
+    echo "✓ Principal already has the Foundry User role"
 fi
 
 

--- a/infra/scripts/run_create_index_scripts.sh
+++ b/infra/scripts/run_create_index_scripts.sh
@@ -74,13 +74,13 @@ fi
 
 # Note: Environment variables are now passed as parameters from process_sample_data.sh
 
-### Assign Azure AI User role to the signed in user for AI Foundry ###
+### Assign Foundry User role to the signed in user for AI Foundry ###
 role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list --role 53ca6127-db72-4b80-b1b0-d745d6d5456d --scope $aif_resource_id --assignee $signed_user_id --query "[].roleDefinitionId" -o tsv)
 if [ -z "$role_assignment" ]; then
-    echo "✓ Assigning Azure AI User role for AI Foundry"
+    echo "✓ Assigning Foundry User role for AI Foundry"
     MSYS_NO_PATHCONV=1 az role assignment create --assignee $signed_user_id --role 53ca6127-db72-4b80-b1b0-d745d6d5456d --scope $aif_resource_id --output none
     if [ $? -ne 0 ]; then
-        echo "✗ Failed to assign Azure AI User role for AI Foundry"
+        echo "✗ Failed to assign Foundry User role for AI Foundry"
         exit 1
     fi
 fi

--- a/src/start.cmd
+++ b/src/start.cmd
@@ -192,21 +192,21 @@ call az sql server ad-admin create ^
     --output tsv >nul 2>&1
 echo Azure SQL Server AAD admin role assigned successfully.
 
-REM Assign Azure AI User role
-echo Checking Azure AI User role assignment...
+REM Assign Foundry User role
+echo Checking Foundry User role assignment...
 if not defined EXISTING_AI_PROJECT_RESOURCE_ID (
     echo Using AI Foundry account scope...
     FOR /F "delims=" %%i IN ('az role assignment list --assignee %signed_user_id% --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" --scope "/subscriptions/%subscription_id%/resourceGroups/%AZURE_RESOURCE_GROUP%/providers/Microsoft.CognitiveServices/accounts/%AI_FOUNDRY_NAME%" --query "[0].id" -o tsv') DO set "aiUserRoleExists=%%i"
     if defined aiUserRoleExists (
-        echo User already has the Azure AI User role.
+        echo User already has the Foundry User role.
     ) else (
-        echo Assigning Azure AI User role to AI Foundry account...
+        echo Assigning Foundry User role to AI Foundry account...
         call az role assignment create ^
             --assignee %signed_user_id% ^
             --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" ^
             --scope "/subscriptions/%subscription_id%/resourceGroups/%AZURE_RESOURCE_GROUP%/providers/Microsoft.CognitiveServices/accounts/%AI_FOUNDRY_NAME%" ^
             --output none
-        echo Azure AI User role assigned successfully.
+        echo Foundry User role assigned successfully.
     )
 ) else (
     echo Extracting foundry scope from existing AI project resource ID...
@@ -216,15 +216,15 @@ if not defined EXISTING_AI_PROJECT_RESOURCE_ID (
     echo Using foundry scope from existing project: !FOUNDRY_SCOPE!
     FOR /F "delims=" %%i IN ('az role assignment list --assignee %signed_user_id% --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" --scope "!FOUNDRY_SCOPE!" --query "[0].id" -o tsv') DO set "aiUserRoleExists=%%i"
     if defined aiUserRoleExists (
-        echo User already has the Azure AI User role.
+        echo User already has the Foundry User role.
     ) else (
-        echo Assigning Azure AI User role to foundry account...
+        echo Assigning Foundry User role to foundry account...
         call az role assignment create ^
             --assignee %signed_user_id% ^
             --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" ^
             --scope "!FOUNDRY_SCOPE!" ^
             --output none
-        echo Azure AI User role assigned successfully.
+        echo Foundry User role assigned successfully.
     )
 )
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -163,8 +163,8 @@ setup_environment() {
         --output tsv >/dev/null 2>&1
     echo "Azure SQL Server AAD admin role assigned successfully."
 
-    # Assign Azure AI User role
-    echo "Checking Azure AI User role assignment..."
+    # Assign Foundry User role
+    echo "Checking Foundry User role assignment..."
     if [ -z "$EXISTING_AI_PROJECT_RESOURCE_ID" ]; then
         echo "Using AI Foundry account scope..."
         echo "AI Foundry Name: $AI_FOUNDRY_NAME"
@@ -195,15 +195,15 @@ setup_environment() {
             --query "[0].id" -o tsv)
         
         if [ -n "$aiUserRoleExists" ]; then
-            echo "User already has the Azure AI User role."
+            echo "User already has the Foundry User role."
         else
-            echo "Assigning Azure AI User role to AI Foundry account..."
+            echo "Assigning Foundry User role to AI Foundry account..."
             az role assignment create \
                 --assignee "$signed_user_id" \
                 --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
                 --scope "$foundryExists" \
                 --output none
-            echo "Azure AI User role assigned successfully."
+            echo "Foundry User role assigned successfully."
         fi
     else
         echo "Extracting foundry scope from existing AI project resource ID..."
@@ -223,15 +223,15 @@ setup_environment() {
             --query "[0].id" -o tsv)
         
         if [ -n "$aiUserRoleExists" ]; then
-            echo "User already has the Azure AI User role."
+            echo "User already has the Foundry User role."
         else
-            echo "Assigning Azure AI User role to foundry account..."
+            echo "Assigning Foundry User role to foundry account..."
             az role assignment create \
                 --assignee "$signed_user_id" \
                 --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
                 --scope "$FOUNDRY_SCOPE" \
                 --output none
-            echo "Azure AI User role assigned successfully."
+            echo "Foundry User role assigned successfully."
         fi
     fi
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request standardizes the naming of a specific Azure role throughout the codebase and documentation, changing all references from "Azure AI User" to "Foundry User". It also updates related comments, messages, and documentation to reflect this new terminology. Additionally, there are minor changes to resource dependency ordering and template formatting to improve clarity and consistency.

**Role Naming Standardization:**

* All references to the "Azure AI User" role are updated to "Foundry User" in Bicep modules (`infra/main.bicep`, `infra/main_custom.bicep`), shell scripts (`infra/scripts/run_create_agents_scripts.sh`, `infra/scripts/run_create_index_scripts.sh`), batch files (`src/start.cmd`), shell scripts (`src/start.sh`), and documentation (`documents/LocalDevelopmentSetup.md`). This includes comments, user-facing messages, and role assignment logic. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L732-R737) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L716-R721) [[3]](diffhunk://#diff-fe0b358ba08a68a66ecc6774c8dd80cbeef7f7df42547afba31aa6eae4dd6ebeL287-R306) [[4]](diffhunk://#diff-21e11cc6b3117a93e991ffaf6e0fb1169e58a590feb0085a11099801b0edb601L77-R83) [[5]](diffhunk://#diff-c3f7c6738ac70844e30969fddf56ea0bde9b31350acfd638413317b3ea599203L195-R209) [[6]](diffhunk://#diff-c3f7c6738ac70844e30969fddf56ea0bde9b31350acfd638413317b3ea599203L219-R227) [[7]](diffhunk://#diff-408951acb4e1dd1f37de3d4508358574cde6c06106566f250e75ab2af0cb231dL166-R167) [[8]](diffhunk://#diff-408951acb4e1dd1f37de3d4508358574cde6c06106566f250e75ab2af0cb231dL198-R206) [[9]](diffhunk://#diff-408951acb4e1dd1f37de3d4508358574cde6c06106566f250e75ab2af0cb231dL226-R234) [[10]](diffhunk://#diff-2ad8cf71fb862ed25e6781c4dbb8a1950b48fa337a058ba02a3573a19f4224ccL392-R395)

**Infrastructure and Template Updates:**

* The `infra/main.json` template hash is updated, and the formatting of the `reactAppLayoutConfig` parameter is improved for readability. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L9-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L399-R399)
* Resource dependency arrays in `infra/main.json` are reordered for clarity and possibly to ensure correct deployment order. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L29630-R29632) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39946-R39949)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

