### PR TITLE
fix: increase e2e test timeouts and improve app readiness check

### DIFF
--- a/.github/workflows/job-test-automation.yml
+++ b/.github/workflows/job-test-automation.yml
@@ -78,25 +78,29 @@ jobs:
       - name: Wait for Application to be Ready
         run: |
           echo "Waiting for application to be ready at ${{ env.url }} "
-          max_attempts=10
+          max_attempts=15
           attempt=1
           
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt: Checking if application is ready..."
-            if curl -f -s "${{ env.url }}" > /dev/null; then
-              echo "Application is ready!"
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${{ env.url }}" || echo "000")
+            if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+              echo "Application is ready! (HTTP $HTTP_STATUS)"
               break
             fi
             
             if [ $attempt -eq $max_attempts ]; then
-              echo "Application is not ready after $max_attempts attempts"
+              echo "Application is not ready after $max_attempts attempts (last HTTP status: $HTTP_STATUS)"
               exit 1
             fi
             
-            echo "Application not ready, waiting 30 seconds..."
+            echo "Application not ready (HTTP $HTTP_STATUS), waiting 30 seconds..."
             sleep 30
             attempt=$((attempt + 1))
           done
+          
+          echo "Waiting additional 30 seconds for application to fully initialize..."
+          sleep 30
 
       - name: Validate Use Case and Test Suite
         run: |
@@ -142,9 +146,9 @@ jobs:
         working-directory: tests/e2e-test
         continue-on-error: true
 
-      - name: Sleep for 30 seconds
+      - name: Sleep for 60 seconds
         if: ${{ steps.test1.outcome == 'failure' }}
-        run: sleep 30s
+        run: sleep 60s
         shell: bash
 
       - name: Run tests(2)
@@ -167,9 +171,9 @@ jobs:
         working-directory: tests/e2e-test
         continue-on-error: true
 
-      - name: Sleep for 60 seconds
+      - name: Sleep for 90 seconds
         if: ${{ steps.test2.outcome == 'failure' }}
-        run: sleep 60s
+        run: sleep 90s
         shell: bash
 
       - name: Run tests(3)

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -27,7 +27,7 @@ class HomePage(BasePage):
         self.page = page
 
     def home_page_load(self):
-        self.page.locator("//span[normalize-space()='Satisfied']").wait_for(state="visible")
+        self.page.locator("//span[normalize-space()='Satisfied']").wait_for(state="visible", timeout=180000)
 
     def validate_response_text(self, question):
         logger.info(f"🔍 DEBUG: validate_response_text called for question: '{question}'")
@@ -89,7 +89,7 @@ class HomePage(BasePage):
         self.page.wait_for_load_state('networkidle')
         self.page.wait_for_timeout(2000)
         try:
-            expect(self.page.locator(self.CHAT_HISTORY_NAME)).to_be_visible(timeout=9000)
+            expect(self.page.locator(self.CHAT_HISTORY_NAME)).to_be_visible(timeout=60000)
         except AssertionError:
             raise AssertionError("Chat history name was not visible on the page within the expected time.")
 


### PR DESCRIPTION
## Problem

The e2e Golden Path test pipeline is failing consistently due to timeout errors:
- **Run 1**: \home_page_load()\ times out (150s) waiting for the app to render
- **Runs 2 & 3**: \show_chat_history()\ fails with only a 9s timeout for chat history visibility

The app appears to be slow/unresponsive when the tests execute, causing all 3 retry attempts to fail.

## Changes

### \	ests/e2e-test/pages/HomePage.py\
- **\home_page_load\**: Set explicit 180s timeout (previously relied on context default of 150s)
- **\show_chat_history\**: Increased timeout from 9s to 60s to handle slow backend responses

### \.github/workflows/job-test-automation.yml\
- Improved health check with proper HTTP status code validation and increased to 15 attempts
- Added 30s post-ready wait for full app initialization after HTTP responds
- Increased retry delays between test runs (60s and 90s instead of 30s and 60s)

## Related
Fixes pipeline failure: https://github.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/actions/runs/26271281861