### PR TITLE
fix: hoist sanitize mapping to module constant, fix U+001E em-dash mismap

### DIFF
--- a/infra/scripts/index_scripts/content_understanding_client.py
+++ b/infra/scripts/index_scripts/content_understanding_client.py
@@ -6,28 +6,31 @@ import time
 from pathlib import Path
 
 
+# Module-level constant: corrupted control-char → intended Unicode mapping.
+# The CU analyzeBinary API (v2025-11-01) intermittently strips the high byte
+# from Unicode characters (e.g. U+2019 → U+0019). This dict maps each known
+# corrupted control character back to its intended equivalent.
+_CU_REPLACEMENTS = {
+    '\u0014': '\u2014',  # em dash
+    '\u0019': '\u2019',  # right single quotation mark
+    '\u001a': '\u201a',  # single low-9 quotation mark
+    '\u001c': '\u201c',  # left double quotation mark
+    '\u001d': '\u201d',  # right double quotation mark
+    '\u001e': '\u201e',  # double low-9 quotation mark
+}
+_CU_BAD_CHARS = set(_CU_REPLACEMENTS.keys())
+
+
 def sanitize_cu_output(text):
-    """Replace non-printable control characters that may appear in CU output.
+    """Replace corrupted control characters that CU may emit.
 
-    The Content Understanding analyzeBinary API (v2025-11-01) intermittently
-    corrupts Unicode characters by stripping the high byte (e.g. U+2019 becomes
-    U+0019).  This function maps each known corrupted control character back to
-    its intended Unicode equivalent.  The mapping is based on empirical
-    observation of characters corrupted in a single high-byte-stripping pass
-    over the U+201x range.
-
-    The fix is zero-cost when CU output is already correct.
+    Returns *text* unchanged (no-op) when none of the known corrupted
+    characters are present.  The replacement mapping is allocated once
+    at module level to avoid per-call overhead.
     """
-    if not text:
+    if not text or _CU_BAD_CHARS.isdisjoint(text):
         return text
-    replacements = {
-        '\u0019': '\u2019',  # right single quotation mark
-        '\u001a': '\u201a',  # single low-9 quotation mark
-        '\u001c': '\u201c',  # left double quotation mark
-        '\u001d': '\u201d',  # right double quotation mark
-        '\u001e': '\u2014',  # em dash (empirically observed)
-    }
-    for bad, good in replacements.items():
+    for bad, good in _CU_REPLACEMENTS.items():
         text = text.replace(bad, good)
     return text
 


### PR DESCRIPTION
## Purpose
Addresses review feedback on PR #922 for the `sanitize_cu_output` function in `content_understanding_client.py`:

1. **Performance**: Hoisted `replacements` dict to module-level constant (`_CU_REPLACEMENTS`) to avoid per-call allocation. Added `_CU_BAD_CHARS` set with `isdisjoint()` early-exit for true no-op when text has no corrupted chars.
2. **Bug fix**: `U+001E` was incorrectly mapped to `U+2014` (em dash). Per the high-byte stripping corruption model, `U+001E` corresponds to `U+201E` (double low-9 quotation mark). Added correct `U+0014` -> `U+2014` mapping for actual em dash corruption.
3. **Docstring**: Removed misleading "zero-cost" claim, clarified no-op semantics.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* `sanitize_cu_output` correctly maps all corrupted control chars back to intended Unicode equivalents
* No regression in CU text processing for `03_cu_process_data_text.py` and `04_cu_process_custom_data.py`

## Other Information
Fixes review comments from PR #922 (comments by Copilot code review).