### PR TITLE
fix: configure Vite CSS modules to match CRA class naming convention

### DIFF
--- a/src/App/vite.config.ts
+++ b/src/App/vite.config.ts
@@ -5,6 +5,11 @@ const backendTarget = process.env.VITE_BACKEND_URL || "http://localhost:8000";
 
 export default defineConfig({
   plugins: [react()],
+  css: {
+    modules: {
+      generateScopedName: "[name]_[local]__[hash:base64:5]",
+    },
+  },
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
## Problem

The Vite migration (part of PR #922) changed how CSS module class names are generated. 

- **CRA (webpack)** generates: \ChatHistoryListItemCell_chatTitle__areVC\ (format: \[name]_[local]__[hash]\)
- **Vite default** generates: \_chatTitle_1a2b3c\ (format: \_[local]_[hash]\)

The e2e test locator \//div[contains(@class, 'ChatHistoryListItemCell_chatTitle')]\ expects the CRA format with the filename prefix. With Vite's default naming, the locator can't find the element → test fails with:

\\\
AssertionError: Chat history name was not visible on the page within the expected time.
\\\

## Fix

Added \css.modules.generateScopedName\ to \ite.config.ts\ to produce CRA-compatible class names:

\\\	s
css: {
  modules: {
    generateScopedName: '[name]_[local]__[hash:base64:5]',
  },
},
\\\

## Related
- Fixes pipeline failure: https://github.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/actions/runs/26271281861
- Related to PR #922 (dev to main - Foundry Roles and sanitize CU output)