### PR TITLE
fix: delete existing search index before creation

### DIFF
--- a/infra/scripts/index_scripts/01_create_search_index.py
+++ b/infra/scripts/index_scripts/01_create_search_index.py
@@ -97,12 +97,10 @@ def create_search_index():
 
     # Delete the index if it already exists
     try:
-        index_client.get_index(INDEX_NAME)
-    except ResourceNotFoundError:
-        pass
-    else:
         index_client.delete_index(INDEX_NAME)
         print(f"✗ Existing search index '{INDEX_NAME}' deleted")
+    except ResourceNotFoundError:
+        pass
 
     # Define and create the index
     index = SearchIndex(

--- a/infra/scripts/index_scripts/01_create_search_index.py
+++ b/infra/scripts/index_scripts/01_create_search_index.py
@@ -16,6 +16,7 @@ from azure.search.documents.indexes.models import (
     VectorSearch,
     VectorSearchProfile,
 )
+from azure.core.exceptions import ResourceNotFoundError
 
 # Get parameters from command line
 p = argparse.ArgumentParser()
@@ -95,8 +96,11 @@ def create_search_index():
     semantic_search = SemanticSearch(configurations=[semantic_config])
 
     # Delete the index if it already exists
-    index_names = [index.name for index in index_client.list_indexes()]
-    if INDEX_NAME in index_names:
+    try:
+        index_client.get_index(INDEX_NAME)
+    except ResourceNotFoundError:
+        pass
+    else:
         index_client.delete_index(INDEX_NAME)
         print(f"✗ Existing search index '{INDEX_NAME}' deleted")
 

--- a/infra/scripts/index_scripts/01_create_search_index.py
+++ b/infra/scripts/index_scripts/01_create_search_index.py
@@ -94,6 +94,12 @@ def create_search_index():
     # Create the semantic settings with the configuration
     semantic_search = SemanticSearch(configurations=[semantic_config])
 
+    # Delete the index if it already exists
+    index_names = [index.name for index in index_client.list_indexes()]
+    if INDEX_NAME in index_names:
+        index_client.delete_index(INDEX_NAME)
+        print(f"✗ Existing search index '{INDEX_NAME}' deleted")
+
     # Define and create the index
     index = SearchIndex(
         name=INDEX_NAME,
@@ -102,7 +108,7 @@ def create_search_index():
         semantic_search=semantic_search
     )
 
-    result = index_client.create_or_update_index(index)
+    result = index_client.create_index(index)
     print(f"✓ Search index '{result.name}' created")
 
 


### PR DESCRIPTION
## Purpose
This pull request updates the search index creation script to ensure that existing indexes are deleted before creating a new one, and simplifies the index creation call. These changes help prevent errors due to duplicate indexes and clarify the index creation process.

**Index management improvements:**

* The script now checks if an index named `INDEX_NAME` already exists and deletes it before creating a new one. This prevents conflicts and ensures a clean setup each time the script runs.

**API usage simplification:**

* Replaces the use of `create_or_update_index` with `create_index` when creating the search index, making the intention explicit and avoiding accidental updates of existing indexes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.