### PR TITLE
fix: updated roleDefinitionIdOrName to use GUID and fixed CodeQL issue.

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -991,17 +991,17 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.31.0' = {
     roleAssignments: [
       {
         principalId: userAssignedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalType: 'ServicePrincipal'
       }
       {
         principalId: userAssignedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage Account Contributor'
+        roleDefinitionIdOrName: '17d1049b-9a84-46fb-8f53-869881c3d3ab' // Storage Account Contributor
         principalType: 'ServicePrincipal'
       }
       {
         principalId: userAssignedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage File Data Privileged Contributor'
+        roleDefinitionIdOrName: '69566ab7-960f-475b-8e7c-b3118f30c6bd' // Storage File Data Privileged Contributor
         principalType: 'ServicePrincipal'
       }
     ]

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "18442421312669656903"
+      "version": "0.44.1.10279",
+      "templateHash": "5914264828980253617"
     }
   },
   "parameters": {
@@ -397,7 +397,7 @@
     "sqlServerResourceName": "[format('sql-{0}', variables('solutionSuffix'))]",
     "sqlDbModuleName": "[format('sqldb-{0}', variables('solutionSuffix'))]",
     "webServerFarmResourceName": "[format('asp-{0}', variables('solutionSuffix'))]",
-    "reactAppLayoutConfig": "{\n  \"appConfig\": {\n    \"THREE_COLUMN\": {\n      \"DASHBOARD\": 50,\n      \"CHAT\": 33,\n      \"CHATHISTORY\": 17\n    },\n    \"TWO_COLUMN\": {\n      \"DASHBOARD_CHAT\": {\n        \"DASHBOARD\": 65,\n        \"CHAT\": 35\n      },\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 80,\n        \"CHATHISTORY\": 20\n      }\n    }\n  },\n  \"charts\": [\n    {\n      \"id\": \"SATISFIED\",\n      \"name\": \"Satisfied\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\n    },\n    {\n      \"id\": \"TOTAL_CALLS\",\n      \"name\": \"Total Calls\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME\",\n      \"name\": \"Average Handling Time\",\n      \"type\": \"card\",\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\n    },\n    {\n      \"id\": \"SENTIMENT\",\n      \"name\": \"Topics Overview\",\n      \"type\": \"donutchart\",\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\n    },\n    {\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\n      \"name\": \"Average Handling Time By Topic\",\n      \"type\": \"bar\",\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\n    },\n    {\n      \"id\": \"TOPICS\",\n      \"name\": \"Trending Topics\",\n      \"type\": \"table\",\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\n    },\n    {\n      \"id\": \"KEY_PHRASES\",\n      \"name\": \"Key Phrases\",\n      \"type\": \"wordcloud\",\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\n    }\n  ]\n}",
+    "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n    \"THREE_COLUMN\": {\r\n      \"DASHBOARD\": 50,\r\n      \"CHAT\": 33,\r\n      \"CHATHISTORY\": 17\r\n    },\r\n    \"TWO_COLUMN\": {\r\n      \"DASHBOARD_CHAT\": {\r\n        \"DASHBOARD\": 65,\r\n        \"CHAT\": 35\r\n      },\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 80,\r\n        \"CHATHISTORY\": 20\r\n      }\r\n    }\r\n  },\r\n  \"charts\": [\r\n    {\r\n      \"id\": \"SATISFIED\",\r\n      \"name\": \"Satisfied\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 1, \"height\": 11 }\r\n    },\r\n    {\r\n      \"id\": \"TOTAL_CALLS\",\r\n      \"name\": \"Total Calls\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 2, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME\",\r\n      \"name\": \"Average Handling Time\",\r\n      \"type\": \"card\",\r\n      \"layout\": { \"row\": 1, \"column\": 3, \"span\": 1 }\r\n    },\r\n    {\r\n      \"id\": \"SENTIMENT\",\r\n      \"name\": \"Topics Overview\",\r\n      \"type\": \"donutchart\",\r\n      \"layout\": { \"row\": 2, \"column\": 1, \"width\": 40, \"height\": 44.5 }\r\n    },\r\n    {\r\n      \"id\": \"AVG_HANDLING_TIME_BY_TOPIC\",\r\n      \"name\": \"Average Handling Time By Topic\",\r\n      \"type\": \"bar\",\r\n      \"layout\": { \"row\": 2, \"column\": 2, \"row-span\": 2, \"width\": 60 }\r\n    },\r\n    {\r\n      \"id\": \"TOPICS\",\r\n      \"name\": \"Trending Topics\",\r\n      \"type\": \"table\",\r\n      \"layout\": { \"row\": 3, \"column\": 1, \"span\": 2 }\r\n    },\r\n    {\r\n      \"id\": \"KEY_PHRASES\",\r\n      \"name\": \"Key Phrases\",\r\n      \"type\": \"wordcloud\",\r\n      \"layout\": { \"row\": 3, \"column\": 2, \"height\": 44.5 }\r\n    }\r\n  ]\r\n}",
     "backendWebSiteResourceName": "[format('api-{0}', variables('solutionSuffix'))]",
     "webSiteResourceName": "[format('app-{0}', variables('solutionSuffix'))]"
   },
@@ -4429,8 +4429,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "14263337584307645476"
+              "version": "0.44.1.10279",
+              "templateHash": "9627102454387562913"
             }
           },
           "definitions": {
@@ -23927,8 +23927,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "16752595662856460651"
+              "version": "0.44.1.10279",
+              "templateHash": "5252655870199315922"
             },
             "name": "Cognitive Services",
             "description": "This module deploys a Cognitive Service."
@@ -25076,8 +25076,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "10918733563560027648"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13713786341946245413"
                     }
                   },
                   "definitions": {
@@ -26726,8 +26726,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.43.8.12551",
-                              "templateHash": "9910113619698591130"
+                              "version": "0.44.1.10279",
+                              "templateHash": "436403693822643644"
                             }
                           },
                           "definitions": {
@@ -26956,8 +26956,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "10918733563560027648"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13713786341946245413"
                     }
                   },
                   "definitions": {
@@ -28606,8 +28606,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.43.8.12551",
-                              "templateHash": "9910113619698591130"
+                              "version": "0.44.1.10279",
+                              "templateHash": "436403693822643644"
                             }
                           },
                           "definitions": {
@@ -29628,9 +29628,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
     },
@@ -31811,8 +31811,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "2967490583129753981"
+              "version": "0.44.1.10279",
+              "templateHash": "14378911215964300033"
             }
           },
           "parameters": {
@@ -31906,8 +31906,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "13704406247129243046"
+              "version": "0.44.1.10279",
+              "templateHash": "13879155259000477210"
             }
           },
           "parameters": {
@@ -32001,17 +32001,17 @@
             "value": [
               {
                 "principalId": "[reference('userAssignedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('userAssignedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "Storage Account Contributor",
+                "roleDefinitionIdOrName": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('userAssignedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "Storage File Data Privileged Contributor",
+                "roleDefinitionIdOrName": "69566ab7-960f-475b-8e7c-b3118f30c6bd",
                 "principalType": "ServicePrincipal"
               }
             ]
@@ -39944,9 +39944,9 @@
         }
       },
       "dependsOn": [
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageDfs)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
         "userAssignedIdentity",
         "virtualNetwork"
@@ -53766,8 +53766,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "6926177947269338708"
+              "version": "0.44.1.10279",
+              "templateHash": "18173420839042785423"
             }
           },
           "definitions": {
@@ -54779,8 +54779,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "1585721918321980475"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13783254618840971873"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -55719,8 +55719,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "6926177947269338708"
+              "version": "0.44.1.10279",
+              "templateHash": "18173420839042785423"
             }
           },
           "definitions": {
@@ -56732,8 +56732,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "1585721918321980475"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13783254618840971873"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -975,17 +975,17 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.31.0' = {
     roleAssignments: [
       {
         principalId: userAssignedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalType: 'ServicePrincipal'
       }
       {
         principalId: userAssignedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage Account Contributor'
+        roleDefinitionIdOrName: '17d1049b-9a84-46fb-8f53-869881c3d3ab' // Storage Account Contributor
         principalType: 'ServicePrincipal'
       }
       {
         principalId: userAssignedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage File Data Privileged Contributor'
+        roleDefinitionIdOrName: '69566ab7-960f-475b-8e7c-b3118f30c6bd' // Storage File Data Privileged Contributor
         principalType: 'ServicePrincipal'
       }
     ]

--- a/src/api/services/_patches/agent_framework_search_citations.py
+++ b/src/api/services/_patches/agent_framework_search_citations.py
@@ -35,7 +35,7 @@ _DOC_INDEX_RE = re.compile(r"^doc_(\d+)$")
 
 logger = logging.getLogger(__name__)
 
-_PATCH_APPLIED = False
+_PATCH_APPLIED = False  # noqa: F841 - used to prevent reapplying patch (checked at line 53)
 _CACHE_ATTR = "_kmsa_search_get_urls_cache"
 _TARGET_METHOD = "_parse_chunk_from_openai"
 _TARGET_CLASS = "RawOpenAIChatClient"
@@ -162,7 +162,7 @@ def apply() -> None:
         return result
 
     setattr(target_cls, _TARGET_METHOD, _patched)
-    _PATCH_APPLIED = True
+    _PATCH_APPLIED = True  # noqa: F841 - marks patch as applied (checked at line 50)
     logger.info(
         "Applied Azure AI Search citation patch on %s.%s (workaround for %s)",
         _TARGET_CLASS, _TARGET_METHOD, _UPSTREAM_ISSUE,

--- a/src/api/services/_patches/agent_framework_search_citations.py
+++ b/src/api/services/_patches/agent_framework_search_citations.py
@@ -35,7 +35,7 @@ _DOC_INDEX_RE = re.compile(r"^doc_(\d+)$")
 
 logger = logging.getLogger(__name__)
 
-_PATCH_APPLIED = False  # noqa: F841 - used to prevent reapplying patch (checked at line 53)
+_PATCH_APPLIED = False  # prevents reapplying patch in apply() guard
 _CACHE_ATTR = "_kmsa_search_get_urls_cache"
 _TARGET_METHOD = "_parse_chunk_from_openai"
 _TARGET_CLASS = "RawOpenAIChatClient"
@@ -162,7 +162,7 @@ def apply() -> None:
         return result
 
     setattr(target_cls, _TARGET_METHOD, _patched)
-    _PATCH_APPLIED = True  # noqa: F841 - marks patch as applied (checked at line 50)
+    _PATCH_APPLIED = True  # marks patch as applied (checked in apply() guard)
     logger.info(
         "Applied Azure AI Search citation patch on %s.%s (workaround for %s)",
         _TARGET_CLASS, _TARGET_METHOD, _UPSTREAM_ISSUE,

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -27,7 +27,7 @@ from agent_framework_foundry import FoundryAgent
 # Restore Azure AI Search per-document URL enrichment on streaming citations
 # (regression at agent-framework GA; tracked upstream as microsoft/agent-framework#5995).
 # Must be imported BEFORE the first FoundryAgent.run() call.
-from services._patches import agent_framework_search_citations as _  # noqa: F401 - patch applied for side effects on import
+import services._patches.agent_framework_search_citations  # noqa: F401 - patch applied for side effects on import
 
 from cachetools import TTLCache
 

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -27,7 +27,7 @@ from agent_framework_foundry import FoundryAgent
 # Restore Azure AI Search per-document URL enrichment on streaming citations
 # (regression at agent-framework GA; tracked upstream as microsoft/agent-framework#5995).
 # Must be imported BEFORE the first FoundryAgent.run() call.
-from services._patches import agent_framework_search_citations  # noqa: F401
+from services._patches import agent_framework_search_citations as _  # noqa: F401 - patch applied for side effects on import
 
 from cachetools import TTLCache
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- Updated the roleDefinitionIdOrName field to use the role definition's GUID instead of the role name.
- Ensures consistent and unambiguous role identification across environments.
- Reduces dependency on role name resolution and avoids issues caused by role renames or localization.
- Improves reliability of role assignment and authorization-related operations.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

