### PR TITLE
fix: disable restore option for AI services modules

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -95,6 +95,7 @@ module aiServices 'modules/ai-services.bicep' = if (!useExistingAiProject) {
     publicNetworkAccess: 'Enabled'
     restrictOutboundNetworkAccess: false
     disableLocalAuth: false
+    restore: false
     deployments: [
       {
         name: chatDeploymentName
@@ -142,6 +143,7 @@ module cuServices 'modules/ai-services.bicep' = {
     publicNetworkAccess: 'Enabled'
     restrictOutboundNetworkAccess: false
     disableLocalAuth: false
+    restore: false
     deployments: []
   }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces a minor update to the AI service configuration in `infra/main.bicep`. The main change is the addition of the `restore: false` property to both the `aiServices` and `cuServices` modules, which likely controls whether the services attempt to restore from a previous state.

Configuration updates:

* Added `restore: false` to the `aiServices` module to explicitly disable restore functionality.
* Added `restore: false` to the `cuServices` module for the same purpose.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

