### PR TITLE
fix: Update aiohttp and pypdf versions in requirements files

### DIFF
--- a/infra/scripts/agent_scripts/requirements.txt
+++ b/infra/scripts/agent_scripts/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.13.4
+aiohttp==3.14.0
 azure-identity==1.25.2
 azure-ai-projects==2.1.0

--- a/infra/scripts/index_scripts/requirements.txt
+++ b/infra/scripts/index_scripts/requirements.txt
@@ -4,7 +4,7 @@ azure-ai-projects==2.1.0
 azure-ai-inference==1.0.0b9
 agent-framework-core==1.3.0
 agent-framework-foundry==1.3.0
-pypdf==6.10.2
+pypdf==6.12.0
 tiktoken==0.12.0
 azure-identity==1.25.2
 azure-ai-textanalytics==5.3.0

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -9,7 +9,7 @@ pydantic[email]==2.13.2
 azure-core==1.39.0
 requests==2.33.1
 types-requests==2.33.0.20260408
-aiohttp==3.13.5
+aiohttp==3.14.0
 
 # Azure Services
 azure-identity==1.25.3


### PR DESCRIPTION
## Purpose

This pull request updates several Python package dependencies across multiple requirements files to ensure compatibility and bring in the latest bug fixes and features. The most important changes are version bumps for key libraries used in the project.

Dependency updates:

* Upgraded `aiohttp` to version 3.14.0 in both `infra/scripts/agent_scripts/requirements.txt` and `src/api/requirements.txt` to maintain consistency and benefit from the latest improvements. [[1]](diffhunk://#diff-835e252ad2ece03d8acbbe3cf435a9ffc85c3ffd51d39cd551e0b844860f6888L1-R1) [[2]](diffhunk://#diff-84c84077c692ad10e8e641fc1875f3fe91fa69085ee82e935cff1f07277da61cL12-R12)
* Updated `pypdf` to version 6.12.0 in `infra/scripts/index_scripts/requirements.txt` for improved PDF handling and bug fixes.

These updates help keep the codebase secure and up-to-date with the latest upstream changes.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pipeline Reference
[![Deploy-Test-Cleanup (v2)](https://github.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/actions/workflows/deploy-v2.yml/badge.svg)](https://github.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/actions/workflows/deploy-v2.yml)

