### PR TITLE
ci: Refactor Docker workflow

### DIFF
--- a/.github/workflows/deploy-orchestrator.yml
+++ b/.github/workflows/deploy-orchestrator.yml
@@ -77,10 +77,8 @@ env:
 
 jobs:
   docker-build:
+    if: inputs.trigger_type == 'workflow_dispatch' && inputs.build_docker_image == true
     uses: ./.github/workflows/job-docker-build.yml
-    with:
-      trigger_type: ${{ inputs.trigger_type }}
-      build_docker_image: ${{ inputs.build_docker_image }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/job-deploy-linux.yml
+++ b/.github/workflows/job-deploy-linux.yml
@@ -289,7 +289,7 @@ jobs:
           azd env set USE_CASE="$USE_CASE"
           
           if [[ "$BUILD_DOCKER_IMAGE" == "true" ]]; then
-            ACR_NAME=$(echo "${{ secrets.ACR_TEST_LOGIN_SERVER }}")
+            ACR_NAME=$(echo "${{ vars.ACR_TEST_LOGIN_SERVER }}")
             azd env set AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT="$ACR_NAME"
             echo "Set ACR name to: $ACR_NAME"
           else

--- a/.github/workflows/job-deploy-windows.yml
+++ b/.github/workflows/job-deploy-windows.yml
@@ -291,7 +291,7 @@ jobs:
           # Set ACR name only when building Docker image
           if ($env:INPUT_BUILD_DOCKER_IMAGE -eq "true") {
             # Extract ACR name from login server and set as environment variable
-            $ACR_NAME = "${{ secrets.ACR_TEST_LOGIN_SERVER }}"
+            $ACR_NAME = "${{ vars.ACR_TEST_LOGIN_SERVER }}"
             azd env set AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT="$ACR_NAME"
             Write-Host "Set ACR name to: $ACR_NAME"
           } else {

--- a/.github/workflows/job-docker-build.yml
+++ b/.github/workflows/job-docker-build.yml
@@ -1,28 +1,22 @@
-name: Docker Build Job
+name: Build & Push Test Images (Feature Branch)
 
 on:
   workflow_call:
-    inputs:
-      trigger_type:
-        description: 'Trigger type (workflow_dispatch, pull_request, schedule)'
-        required: true
-        type: string
-      build_docker_image:
-        description: 'Build And Push Docker Image (Optional)'
-        required: false
-        default: false
-        type: boolean
     outputs:
       IMAGE_TAG:
         description: "Generated Docker Image Tag"
         value: ${{ jobs.docker-build.outputs.IMAGE_TAG }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
 
 env:
   BRANCH_NAME: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 
 jobs:
   docker-build:
-    if: inputs.trigger_type == 'workflow_dispatch' && inputs.build_docker_image == true
     runs-on: ubuntu-latest
     environment: production
     outputs:
@@ -57,7 +51,7 @@ jobs:
 
       - name: Log in to Azure Container Registry
         run: |
-          ACR_NAME=$(echo "${{ secrets.ACR_TEST_LOGIN_SERVER }}" | sed 's/\.azurecr\.io$//')
+          ACR_NAME=$(echo "${{ vars.ACR_TEST_LOGIN_SERVER }}" | sed 's/\.azurecr\.io$//')
           az acr login --name "$ACR_NAME"
 
       - name: Build and Push Docker Image for WebApp
@@ -69,8 +63,8 @@ jobs:
           file: ./src/App/WebApp.Dockerfile
           push: True
           tags: |
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/km-app:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/km-app:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/km-app:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/km-app:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
 
       - name: Build and Push Docker Image for API
         uses: docker/build-push-action@v6
@@ -81,8 +75,8 @@ jobs:
           file: ./src/api/ApiApp.Dockerfile
           push: True
           tags: |
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/km-api:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/km-api:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/km-api:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/km-api:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
 
       - name: Verify Docker Image Build
         shell: bash
@@ -94,7 +88,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          ACR_NAME=$(echo "${{ secrets.ACR_TEST_LOGIN_SERVER }}")
+          ACR_NAME=$(echo "${{ vars.ACR_TEST_LOGIN_SERVER }}")
           echo "## 🐳 Docker Build Job Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Purpose
This pull request updates our GitHub Actions workflows to improve how we handle Azure Container Registry (ACR) configuration, primarily by switching from using GitHub secrets to using GitHub environment variables (`vars`). It also refines the Docker build workflow triggers and permissions for better security and maintainability.

Key changes include:

**ACR Configuration Updates:**
* Replaced all references to `secrets.ACR_TEST_LOGIN_SERVER` with `vars.ACR_TEST_LOGIN_SERVER` in the Docker build and deploy workflows, ensuring that ACR endpoints are now sourced from environment variables instead of secrets. This change affects the Docker login step, image tagging, and deployment scripts in both Linux and Windows jobs. [[1]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL60-R54) [[2]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL72-R67) [[3]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL84-R79) [[4]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL97-R91) [[5]](diffhunk://#diff-0602978fc8fc7dd24cfa7aa076b45f9264d4c0c574d8bf0b66434835968420b5L292-R292) [[6]](diffhunk://#diff-4c3acc8de63274ed8be3d7d9c1f2f6cf9b86e46e7e3079889973be9eb760adbdL294-R294)

**Workflow Triggers and Inputs:**
* Removed workflow inputs (`trigger_type`, `build_docker_image`) from `job-docker-build.yml`, and added a `workflow_dispatch` trigger. This simplifies how the workflow is triggered and removes unnecessary complexity.
* Updated the `deploy-orchestrator.yml` workflow to add a conditional check on the `docker-build` job, now only running it when triggered manually and when building Docker images, aligning with the new trigger logic.

**Permissions:**
* Explicitly set permissions for the Docker build workflow, granting read access to contents and write access to the ID token, which is a best practice for secure workflows.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

