### PR TITLE
fix: update appCommandLine and environment variable names for custom code deployment

### DIFF
--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1441,7 +1441,7 @@ module webSiteFrontend 'modules/web-sites.bicep' = {
       linuxFxVersion: 'NODE|20-lts'
       minTlsVersion: '1.2'
       alwaysOn: true
-      appCommandLine: 'pm2 serve /home/site/wwwroot/build --no-daemon --spa'
+      appCommandLine: 'pm2 serve /home/site/wwwroot/dist --no-daemon --spa'
     }
     configs: [
       {
@@ -1449,7 +1449,7 @@ module webSiteFrontend 'modules/web-sites.bicep' = {
         properties: {
           SCM_DO_BUILD_DURING_DEPLOYMENT: 'true'
           ENABLE_ORYX_BUILD: 'true'
-          REACT_APP_API_BASE_URL: enablePrivateNetworking ? '' : 'https://api-${solutionSuffix}.azurewebsites.net'
+          VITE_API_BASE_URL: enablePrivateNetworking ? '' : 'https://api-${solutionSuffix}.azurewebsites.net'
           WEBSITE_NODE_DEFAULT_VERSION: '~20'
           APP_API_BASE_URL: enablePrivateNetworking ? '' : 'https://api-${solutionSuffix}.azurewebsites.net'
           BACKEND_API_HOST: enablePrivateNetworking ? 'api-${solutionSuffix}.azurewebsites.net' : ''


### PR DESCRIPTION
## Purpose
Updates the Azure App Service configuration for the frontend to align with a build output directory change and a new frontend env var prefix.

Changes:
Serve frontend assets from /home/site/wwwroot/dist instead of /home/site/wwwroot/build
Switch frontend API base URL app setting from REACT_APP_API_BASE_URL to VITE_API_BASE_URL

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.