### PR TITLE
fix: Add SQL role assignment to agent setup and update image tags

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -36,6 +36,13 @@ hooks:
           Write-Host "WARNING: Agent setup failed — you can retry later with: ./infra/scripts/setup-agent.ps1" -ForegroundColor Yellow
         }
 
+        # ── Step 1.5: Grant API identity access to SQL ──
+        Write-Host ""
+        & ./infra/scripts/setup-sql-roles.ps1
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "WARNING: SQL role assignment failed — retry later with: ./infra/scripts/setup-sql-roles.ps1" -ForegroundColor Yellow
+        }
+
         # ── Step 2: Choose use case or data source ──
         Write-Host ""
         & ./scripts/setup-data.ps1
@@ -72,6 +79,10 @@ hooks:
         echo ""
         echo "Setting up AI agent..."
         pwsh -File ./infra/scripts/setup-agent.ps1 || echo "WARNING: Agent setup failed — retry with: ./infra/scripts/setup-agent.ps1"
+
+        echo ""
+        echo "Granting API identity SQL access..."
+        pwsh -File ./infra/scripts/setup-sql-roles.ps1 || echo "WARNING: SQL role assignment failed — retry with: ./infra/scripts/setup-sql-roles.ps1"
 
         echo ""
         pwsh -File ./scripts/setup-data.ps1

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -36,13 +36,13 @@
       "value": "${BACKEND_CONTAINER_REGISTRY=kmgendeploypipeline.azurecr.io}"
     },
     "backendContainerImageTag": {
-      "value": "${BACKEND_IMAGE_TAG=modularity_23062026}"
+      "value": "${BACKEND_IMAGE_TAG=modularity}"
     },
     "frontendContainerRegistryHostname": {
       "value": "${FRONTEND_CONTAINER_REGISTRY=kmgendeploypipeline.azurecr.io}"
     },
     "frontendContainerImageTag": {
-      "value": "${FRONTEND_IMAGE_TAG=modularity_23062026}"
+      "value": "${FRONTEND_IMAGE_TAG=modularity}"
     }
   }
 }

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -42,10 +42,19 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
   }
 }
 
-// Allow Azure services to access
-resource firewallRule 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+resource firewallRule 'Microsoft.Sql/servers/firewallRules@2025-01-01' = {
+  name: 'AllowSpecificRange'
   parent: sqlServer
-  name: 'AllowAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '255.255.255.255'
+  }
+}
+
+// Allow Azure services to access
+resource AllowAllWindowsAzureIps 'Microsoft.Sql/servers/firewallRules@2025-01-01' = {
+  name: 'AllowAllWindowsAzureIps'
+  parent: sqlServer
   properties: {
     startIpAddress: '0.0.0.0'
     endIpAddress: '0.0.0.0'


### PR DESCRIPTION
## Purpose
This pull request introduces improvements to the Azure deployment scripts and infrastructure templates, mainly focusing on automating SQL role assignments, updating image tag handling, and refining SQL firewall rule resources for better clarity and compatibility.

**Deployment automation and infrastructure updates:**

* Added a step in both PowerShell (`setup.ps1`) and Bash setup scripts to automatically grant the API identity access to the SQL database by running `setup-sql-roles.ps1`. This helps ensure the API can access the database without manual intervention. [[1]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R39-R45) [[2]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R83-R86)

**Infrastructure parameter updates:**

* Changed the default values for `backendContainerImageTag` and `frontendContainerImageTag` in `infra/main.parameters.json` to use the generic `modularity` tag instead of a date-specific tag. This simplifies image versioning and reduces the need for frequent updates.

**SQL firewall rule improvements:**

* Updated `infra/modules/sql.bicep` to:
  - Add a new firewall rule (`AllowSpecificRange`) that opens SQL access to all IP addresses (from `0.0.0.0` to `255.255.255.255`), which may be for development or testing purposes.
  - Rename and update the Azure services firewall rule to `AllowAllWindowsAzureIps` and use the latest API version for compatibility and clarity.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No