### PR TITLE
chore: update CODEOWNERS handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @Avijit-Microsoft @Roopan-Microsoft @Prajwal-Microsoft @aniaroramsft @brittneek @Vinay-Microsoft @toherman-msft @nchandhi @dgp10801
+* @Avijit-Microsoft @Roopan-Microsoft @Prajwal1-Microsoft @aniaroramsft @brittneek @VinaySh-Microsoft @toherman-msft @nchandhi @dgp10801


### PR DESCRIPTION
## Purpose
* Update CODEOWNERS to replace two GitHub handles with their current accounts.
  * `@Vinay-Microsoft` -> `@VinaySh-Microsoft`
  * `@Prajwal-Microsoft` -> `@Prajwal1-Microsoft`

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## How to Test
* No functional change; metadata only. Verify CODEOWNERS parses and references active accounts.

## What to Check
* `.github/CODEOWNERS` references the correct, active accounts.

## Other Information
Handle-only update; no functional changes.