### PR TITLE
fix: Updated build_and_push_images.sh for WAF

### DIFF
--- a/infra/scripts/build_and_push_images.sh
+++ b/infra/scripts/build_and_push_images.sh
@@ -28,14 +28,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 resourceGroupName=""
 
 while [[ $# -gt 0 ]]; do
-	case "$1" in
-		*)
-			if [ -z "$resourceGroupName" ]; then
-				resourceGroupName="$1"
-			fi
-			shift
-			;;
-	esac
+    case "$1" in
+        *)
+            if [ -z "$resourceGroupName" ]; then
+                resourceGroupName="$1"
+            fi
+            shift
+            ;;
+    esac
 done
 
 # Backend (km-api) and frontend (km-app) build contexts and Dockerfiles
@@ -61,162 +61,200 @@ original_acr_public_access=""
 # Helpers
 # ---------------------------------------------------------------------------
 check_azd_installed() {
-	command -v azd >/dev/null 2>&1
+    command -v azd >/dev/null 2>&1
 }
 
 get_values_from_azd_env() {
-	echo "Getting values from azd environment..."
-	resourceGroupName=$(azd env get-value RESOURCE_GROUP_NAME 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
-	acrName=$(azd env get-value ACR_NAME 2>&1 | grep -E '^[a-zA-Z0-9]+$')
-	acrLoginServer=$(azd env get-value ACR_LOGIN_SERVER 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
-	backendImageName=$(azd env get-value BACKEND_CONTAINER_IMAGE_NAME 2>&1 | grep -E '^[a-zA-Z0-9._/-]+$')
-	backendImageTag=$(azd env get-value BACKEND_CONTAINER_IMAGE_TAG 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
-	frontendImageName=$(azd env get-value FRONTEND_CONTAINER_IMAGE_NAME 2>&1 | grep -E '^[a-zA-Z0-9._/-]+$')
-	frontendImageTag=$(azd env get-value FRONTEND_CONTAINER_IMAGE_TAG 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
-	backendAppName=$(azd env get-value API_APP_NAME 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
-	frontendAppName=$(azd env get-value FRONTEND_APP_NAME 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
+    echo "Getting values from azd environment..."
+    resourceGroupName=$(azd env get-value RESOURCE_GROUP_NAME 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
+    acrName=$(azd env get-value ACR_NAME 2>&1 | grep -E '^[a-zA-Z0-9]+$')
+    acrLoginServer=$(azd env get-value ACR_LOGIN_SERVER 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
+    backendImageName=$(azd env get-value BACKEND_CONTAINER_IMAGE_NAME 2>&1 | grep -E '^[a-zA-Z0-9._/-]+$')
+    backendImageTag=$(azd env get-value BACKEND_CONTAINER_IMAGE_TAG 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
+    frontendImageName=$(azd env get-value FRONTEND_CONTAINER_IMAGE_NAME 2>&1 | grep -E '^[a-zA-Z0-9._/-]+$')
+    frontendImageTag=$(azd env get-value FRONTEND_CONTAINER_IMAGE_TAG 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
+    backendAppName=$(azd env get-value API_APP_NAME 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
+    frontendAppName=$(azd env get-value FRONTEND_APP_NAME 2>&1 | grep -E '^[a-zA-Z0-9._-]+$')
 
-	if [ -z "$resourceGroupName" ] || [ -z "$acrName" ] || [ -z "$backendAppName" ] || [ -z "$frontendAppName" ]; then
-		echo "Error: One or more required values could not be retrieved from azd environment."
-		return 1
-	fi
-	return 0
+    if [ -z "$resourceGroupName" ] || [ -z "$acrName" ] || [ -z "$backendAppName" ] || [ -z "$frontendAppName" ]; then
+        echo "Error: One or more required values could not be retrieved from azd environment."
+        return 1
+    fi
+    return 0
 }
 
 get_values_from_az_deployment() {
-	echo "Getting values from Azure deployment outputs..."
+    echo "Getting values from Azure deployment outputs..."
 
-	deploymentName=$(az group show --name "$resourceGroupName" --query "tags.DeploymentName" -o tsv)
-	echo "Deployment Name (from tag): $deploymentName"
+    deploymentName=$(az group show --name "$resourceGroupName" --query "tags.DeploymentName" -o tsv)
+    echo "Deployment Name (from tag): $deploymentName"
 
-	deploymentOutputs=$(az deployment group show \
-		--name "$deploymentName" \
-		--resource-group "$resourceGroupName" \
-		--query "properties.outputs" -o json)
+    echo "Fetching deployment outputs..."
+    deploymentOutputs=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs" -o json)
 
-	extract_value() {
-		echo "$deploymentOutputs" | grep -i -A 3 "\"$1\"" | grep '"value"' | sed 's/.*"value": *"\([^"]*\)".*/\1/'
-	}
+    # Helper function to extract value from deployment outputs
+    # Usage: extract_value "primaryKey" "fallbackKey"
+    extract_value() {
+        local primary_key="$1"
+        local fallback_key="$2"
+        local value
 
-	acrName=$(extract_value "ACR_NAME")
-	acrLoginServer=$(extract_value "ACR_LOGIN_SERVER")
-	backendImageName=$(extract_value "BACKEND_CONTAINER_IMAGE_NAME")
-	backendImageTag=$(extract_value "BACKEND_CONTAINER_IMAGE_TAG")
-	frontendImageName=$(extract_value "FRONTEND_CONTAINER_IMAGE_NAME")
-	frontendImageTag=$(extract_value "FRONTEND_CONTAINER_IMAGE_TAG")
-	backendAppName=$(extract_value "API_APP_NAME")
-	frontendAppName=$(extract_value "FRONTEND_APP_NAME")
+        value=$(echo "$deploymentOutputs" | grep -i -A 3 "\"$primary_key\"" | grep '"value"' | sed 's/.*"value": *"\([^"]*\)".*/\1/')
 
-	if [ -z "$acrName" ] || [ -z "$backendAppName" ] || [ -z "$frontendAppName" ]; then
-		echo "Error: One or more required values could not be retrieved from deployment outputs."
-		return 1
-	fi
-	return 0
+        if [ -z "$value" ] && [ -n "$fallback_key" ]; then
+            value=$(echo "$deploymentOutputs" | grep -i -A 3 "\"$fallback_key\"" | grep '"value"' | sed 's/.*"value": *"\([^"]*\)".*/\1/')
+        fi
+
+        echo "$value"
+    }
+
+    # Extract deployment outputs
+    acrName=$(extract_value "acR_NAME" "ACR_NAME")
+    acrLoginServer=$(extract_value "acR_LOGIN_SERVER" "ACR_LOGIN_SERVER")
+    backendImageName=$(extract_value "backenD_CONTAINER_IMAGE_NAME" "BACKEND_CONTAINER_IMAGE_NAME")
+    backendImageTag=$(extract_value "backenD_CONTAINER_IMAGE_TAG" "BACKEND_CONTAINER_IMAGE_TAG")
+    frontendImageName=$(extract_value "frontenD_CONTAINER_IMAGE_NAME" "FRONTEND_CONTAINER_IMAGE_NAME")
+    frontendImageTag=$(extract_value "frontenD_CONTAINER_IMAGE_TAG" "FRONTEND_CONTAINER_IMAGE_TAG")
+    backendAppName=$(extract_value "apI_APP_NAME" "API_APP_NAME")
+    frontendAppName=$(extract_value "frontenD_APP_NAME" "FRONTEND_APP_NAME")
+
+    # Define required values with their display names
+    declare -A required_values=(
+        ["acrName"]="ACR_NAME"
+        ["acrLoginServer"]="ACR_LOGIN_SERVER"
+        ["backendImageName"]="BACKEND_CONTAINER_IMAGE_NAME"
+        ["backendImageTag"]="BACKEND_CONTAINER_IMAGE_TAG"
+        ["frontendImageName"]="FRONTEND_CONTAINER_IMAGE_NAME"
+        ["frontendImageTag"]="FRONTEND_CONTAINER_IMAGE_TAG"
+        ["backendAppName"]="API_APP_NAME"
+        ["frontendAppName"]="FRONTEND_APP_NAME"
+    )
+
+    # Validate required values
+    missing_values=()
+    for var_name in "${!required_values[@]}"; do
+        if [ -z "${!var_name}" ]; then
+            missing_values+=("${required_values[$var_name]}")
+        fi
+    done
+    if [ ${#missing_values[@]} -gt 0 ]; then
+        echo "Error: The following required values could not be retrieved from Azure deployment outputs:"
+        printf '  - %s\n' "${missing_values[@]}" | sort
+        return 1
+    fi
+    return 0
 }
 
 # Enable public network access on ACR temporarily (needed for remote builds on WAF deployments)
 enable_acr_public_access() {
-	original_acr_public_access=$(az acr show \
-		--name "$acrName" \
-		--resource-group "$resourceGroupName" \
-		--query "publicNetworkAccess" -o tsv 2>/dev/null)
+    original_acr_public_access=$(az acr show \
+        --name "$acrName" \
+        --resource-group "$resourceGroupName" \
+        --query "publicNetworkAccess" -o tsv 2>/dev/null)
 
-	if [ -z "$original_acr_public_access" ]; then
-		echo "⚠ Could not retrieve ACR network access status"
-		return 0
-	fi
+    if [ -z "$original_acr_public_access" ]; then
+        echo "[WARN] Could not retrieve ACR network access status"
+    fi
 
-	if [ "$original_acr_public_access" != "Enabled" ]; then
-		echo "✓ Temporarily enabling ACR public network access"
-		az acr update \
-			--name "$acrName" \
-			--resource-group "$resourceGroupName" \
-			--public-network-access Enabled \
-			--default-action Allow \
-			--output none
-		# Wait a bit for the change to take effect
-		sleep 20
-	fi
-	return 0
+    if [ "$original_acr_public_access" != "Enabled" ]; then
+        echo "[OK] Temporarily enabling ACR public network access"
+        az acr update \
+            --name "$acrName" \
+            --resource-group "$resourceGroupName" \
+            --public-network-enabled true \
+            --default-action Allow \
+            --output none
+        # Wait a bit for the change to take effect
+        sleep 20
+    fi
+    return 0
 }
 
 # Restore original ACR public network access state
 restore_acr_public_access() {
-	if [ -n "$original_acr_public_access" ] && [ "$original_acr_public_access" != "Enabled" ]; then
-		echo "✓ Restoring ACR public network access to '$original_acr_public_access'"
-		az acr update \
-			--name "$acrName" \
-			--resource-group "$resourceGroupName" \
-			--public-network-access "$original_acr_public_access" \
-			--default-action Deny \
-			--output none 2>/dev/null || echo "⚠ Failed to restore ACR public network access - please check the Azure portal"
-	fi
+    if [ -n "$original_acr_public_access" ] && [ "$original_acr_public_access" != "Enabled" ]; then
+        echo "[OK] Restoring ACR public network access to '$original_acr_public_access'"
+        case "$original_acr_public_access" in
+            "enabled"|"Enabled") restore_value=true ;;
+            "disabled"|"Disabled") restore_value=false ;;
+            *) restore_value="$original_acr_public_access" ;;
+        esac
+        az acr update \
+            --name "$acrName" \
+            --resource-group "$resourceGroupName" \
+            --public-network-enabled $restore_value \
+            --default-action Deny \
+            --output none 2>/dev/null || echo "[WARN] Failed to restore ACR public network access - please check the Azure portal"
+    fi
 }
 
 cleanup_on_exit() {
-	exit_code=$?
-	restore_acr_public_access
-	echo ""
-	if [ $exit_code -ne 0 ]; then
-		echo "❌ Script failed"
-	else
-		echo "✅ Script completed successfully"
-	fi
-	exit $exit_code
+    exit_code=$?
+    restore_acr_public_access
+    echo ""
+    if [ $exit_code -ne 0 ]; then
+        echo "[FAILED] Script failed"
+    else
+        echo "[SUCCESS] Script completed successfully"
+    fi
+    exit $exit_code
 }
 trap cleanup_on_exit EXIT
 
 # Build and push a single image
 # Args: <context> <dockerfile> <imageName> <imageTag>
 build_and_push_image() {
-	local context="$1"
-	local dockerfile="$2"
-	local imageName="$3"
-	local imageTag="$4"
-	local imageRef="${imageName}:${imageTag}"
+    local context="$1"
+    local dockerfile="$2"
+    local imageName="$3"
+    local imageTag="$4"
+    local imageRef="${imageName}:${imageTag}"
 
-	if [ ! -f "$dockerfile" ]; then
-		echo "✗ Dockerfile not found: $dockerfile"
-		return 1
-	fi
+    if [ ! -f "$dockerfile" ]; then
+        echo "[ERROR] Dockerfile not found: $dockerfile"
+        return 1
+    fi
 
-	echo "→ Building '$imageRef' remotely in ACR '$acrName'..."
-	az acr build \
-		--registry "$acrName" \
-		--image "$imageRef" \
-		--file "$dockerfile" \
-		--platform linux \
-		"$context"
+    echo "Building '$imageRef' remotely in ACR '$acrName'..."
+    az acr build \
+        --registry "$acrName" \
+        --image "$imageRef" \
+        --file "$dockerfile" \
+        --platform linux \
+        "$context"
 }
 
 # Update an App Service to run an ACR image using managed identity credentials
 # Args: <appName> <imageName> <imageTag>
 update_web_app_image() {
-	local appName="$1"
-	local imageName="$2"
-	local imageTag="$3"
-	local fullImage="${acrLoginServer}/${imageName}:${imageTag}"
+    local appName="$1"
+    local imageName="$2"
+    local imageTag="$3"
+    local fullImage="${acrLoginServer}/${imageName}:${imageTag}"
 
-	echo "→ Updating App Service '$appName' to use image '$fullImage'..."
-	az webapp config container set \
-		--name "$appName" \
-		--resource-group "$resourceGroupName" \
-		--container-image-name "$fullImage" \
-		--container-registry-url "https://${acrLoginServer}" \
-		--only-show-errors \
-		--output none
+    echo "Updating App Service '$appName' to use image '$fullImage'..."
+    az webapp config container set \
+        --name "$appName" \
+        --resource-group "$resourceGroupName" \
+        --container-image-name "$fullImage" \
+        --container-registry-url "https://${acrLoginServer}" \
+        --only-show-errors \
+        --output none
 
-	# Ensure the app pulls the image using its managed identity (no admin credentials)
-	az resource update \
-		--resource-group "$resourceGroupName" \
-		--namespace Microsoft.Web \
-		--resource-type sites \
-		--name "$appName" \
-		--set properties.siteConfig.acrUseManagedIdentityCreds=true \
-		--output none 2>/dev/null || true
+    # Ensure the app pulls the image using its managed identity (no admin credentials)
+    az resource update \
+        --resource-group "$resourceGroupName" \
+        --namespace Microsoft.Web \
+        --resource-type sites \
+        --name "$appName" \
+        --set properties.siteConfig.acrUseManagedIdentityCreds=true \
+        --output none 2>/dev/null || true
 
-	echo "→ Restarting App Service '$appName'..."
-	az webapp restart --name "$appName" --resource-group "$resourceGroupName" --output none
+    echo "Restarting App Service '$appName'..."
+    az webapp restart --name "$appName" --resource-group "$resourceGroupName" --output none
 }
 
 # ---------------------------------------------------------------------------
@@ -229,29 +267,29 @@ echo "==============================================="
 # Check Azure authentication
 echo "Checking Azure authentication..."
 if az account show &>/dev/null; then
-	echo "Already authenticated with Azure."
+    echo "Already authenticated with Azure."
 else
-	echo "Authenticating with Azure CLI..."
-	if ! az login --use-device-code; then
-		echo "✗ Failed to authenticate with Azure"
-		exit 1
-	fi
+    echo "Authenticating with Azure CLI..."
+    if ! az login --use-device-code; then
+        echo "[ERROR] Failed to authenticate with Azure"
+        exit 1
+    fi
 fi
 
 # Resolve configuration values
 if [ -z "$resourceGroupName" ]; then
-	if ! get_values_from_azd_env; then
-		echo ""
-		echo "Failed to get values from azd environment."
-		echo "Provide a resource group name to resolve values from deployment outputs instead:"
-		echo "  Usage: $0 [ResourceGroupName]"
-		exit 1
-	fi
+    if ! get_values_from_azd_env; then
+        echo ""
+        echo "Failed to get values from azd environment."
+        echo "Provide a resource group name to resolve values from deployment outputs instead:"
+        echo "  Usage: $0 [ResourceGroupName]"
+        exit 1
+    fi
 else
-	if ! get_values_from_az_deployment; then
-		echo "Failed to get values from deployment outputs."
-		exit 1
-	fi
+    if ! get_values_from_az_deployment; then
+        echo "Failed to get values from deployment outputs."
+        exit 1
+    fi
 fi
 
 # Fallbacks / defaults


### PR DESCRIPTION
## Purpose
This pull request refactors and improves the `infra/scripts/build_and_push_images.sh` script to enhance reliability, error handling, and clarity of output. The main improvements include robust extraction and validation of Azure deployment outputs, clearer and more consistent status messaging, and more reliable handling of Azure Container Registry (ACR) public network access settings.

**Deployment output extraction and validation:**
- Replaces the simple `extract_value` function with a more robust version that can attempt to extract values using both a primary and fallback key, improving resilience to key name inconsistencies. Missing required values are now clearly reported with a sorted list, and the script exits early if any are missing.

**ACR public network access handling:**
- Updates the commands for enabling and restoring ACR public network access to use the correct Azure CLI flags (`--public-network-enabled` instead of `--public-network-access`) and normalizes status values for reliable restoration. Status messages are standardized and clarified. [[1]](diffhunk://#diff-47590cb5a89f8213598af2380365ca827d930522bad7612f27bfb66bc08fc4e3L125-R167) [[2]](diffhunk://#diff-47590cb5a89f8213598af2380365ca827d930522bad7612f27bfb66bc08fc4e3L146-R190)

**Status and error messaging:**
- Replaces emoji-based status messages with clear, bracketed messages (e.g., `[ERROR]`, `[SUCCESS]`, `[WARN]`, `[OK]`, `[FAILED]`) throughout the script for improved readability and consistency in logs. [[1]](diffhunk://#diff-47590cb5a89f8213598af2380365ca827d930522bad7612f27bfb66bc08fc4e3L179-R221) [[2]](diffhunk://#diff-47590cb5a89f8213598af2380365ca827d930522bad7612f27bfb66bc08fc4e3L200-R238) [[3]](diffhunk://#diff-47590cb5a89f8213598af2380365ca827d930522bad7612f27bfb66bc08fc4e3L218-R256) [[4]](diffhunk://#diff-47590cb5a89f8213598af2380365ca827d930522bad7612f27bfb66bc08fc4e3L236-R274)

These changes make the script more robust, easier to maintain, and friendlier for both automation and manual review.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
