### PR TITLE
fix: add .env configuration file for Azure settings

### DIFF
--- a/infra/vscode_web/.env
+++ b/infra/vscode_web/.env
@@ -1,0 +1,7 @@
+AZURE_EXISTING_AGENT_ID="<%= agentId %>"
+AZURE_ENV_NAME="<%= playgroundName %>"
+# AZURE_LOCATION="<%= location %>"
+AZURE_SUBSCRIPTION_ID="<%= subscriptionId %>"
+AZURE_EXISTING_AIPROJECT_ENDPOINT="<%= endpoint %>"
+AZURE_EXISTING_AIPROJECT_RESOURCE_ID="<%= projectResourceId %>"
+AZD_ALLOW_NON_EMPTY_FOLDER=true


### PR DESCRIPTION
## Purpose
This pull request adds several Azure-related environment variables to the `.env` file for the `infra/vscode_web` project. These variables are likely intended to support Azure integration and deployment automation.

Azure environment configuration:

* Added `AZURE_EXISTING_AGENT_ID`, `AZURE_ENV_NAME`, `AZURE_SUBSCRIPTION_ID`, `AZURE_EXISTING_AIPROJECT_ENDPOINT`, and `AZURE_EXISTING_AIPROJECT_RESOURCE_ID` to store Azure resource identifiers and configuration values.
* Set `AZD_ALLOW_NON_EMPTY_FOLDER=true` to permit deployment or setup in non-empty folders.
* Commented out `AZURE_LOCATION`, possibly for future use or to allow for manual specification.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.