### PR TITLE
fix: Select Azure credentials by environment

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -46,6 +46,9 @@ class Settings(BaseSettings):
     azure_ad_tenant_id: str = ""
     azure_ad_client_id: str = ""
 
+    # Optional user-assigned managed identity. Empty uses the system-assigned identity.
+    azure_client_id: str = ""
+
     # RAG Configuration
     rag_top_k: int = 5
     rag_enable_reranking: bool = False

--- a/src/api/modules/data_sources/azure_search.py
+++ b/src/api/modules/data_sources/azure_search.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from typing import Iterator, Optional
 
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.search.documents import SearchClient
 
 from src.api.modules.data_sources.base import (
@@ -12,6 +12,7 @@ from src.api.modules.data_sources.base import (
     ColumnInfo,
     DataSourceConfig,
 )
+from src.api.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,13 @@ class AzureSearchDataSource(BaseExternalDataSource):
     """Adapter for Azure AI Search — enables BYOI (bring your own index)."""
 
     def _get_client(self, config: DataSourceConfig) -> SearchClient:
-        credential = DefaultAzureCredential()
+        settings = get_settings()
+        if settings.app_env.lower() == "dev":
+            credential = DefaultAzureCredential(require_envvar=True)
+        else:
+            credential = ManagedIdentityCredential(
+                client_id=settings.azure_client_id or None
+            )
         return SearchClient(
             endpoint=config.endpoint,
             index_name=config.table_or_query,  # index name stored in table_or_query

--- a/src/api/modules/data_sources/azure_search.py
+++ b/src/api/modules/data_sources/azure_search.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from typing import Iterator, Optional
 
-from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+from azure.identity import AzureCliCredential, ManagedIdentityCredential
 from azure.search.documents import SearchClient
 
 from src.api.modules.data_sources.base import (
@@ -23,7 +23,7 @@ class AzureSearchDataSource(BaseExternalDataSource):
     def _get_client(self, config: DataSourceConfig) -> SearchClient:
         settings = get_settings()
         if settings.app_env.lower() == "dev":
-            credential = DefaultAzureCredential(require_envvar=True)
+            credential = AzureCliCredential()
         else:
             credential = ManagedIdentityCredential(
                 client_id=settings.azure_client_id or None

--- a/src/api/modules/ingestion/azure_storage.py
+++ b/src/api/modules/ingestion/azure_storage.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 from datetime import datetime, timedelta, timezone
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.storage.blob import BlobServiceClient, ContentSettings, generate_blob_sas, BlobSasPermissions
 from azure.search.documents import SearchClient
 from azure.search.documents.indexes import SearchIndexClient
@@ -29,7 +29,13 @@ class AzureStorageService:
 
     def _get_credential(self):
         if self._credential is None:
-            self._credential = DefaultAzureCredential()
+            settings = get_settings()
+            if settings.app_env.lower() == "dev":
+                self._credential = DefaultAzureCredential(require_envvar=True)
+            else:
+                self._credential = ManagedIdentityCredential(
+                    client_id=settings.azure_client_id or None
+                )
         return self._credential
 
     def _get_blob_client(self) -> BlobServiceClient:

--- a/src/api/modules/ingestion/azure_storage.py
+++ b/src/api/modules/ingestion/azure_storage.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 from datetime import datetime, timedelta, timezone
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+from azure.identity import AzureCliCredential, ManagedIdentityCredential
 from azure.storage.blob import BlobServiceClient, ContentSettings, generate_blob_sas, BlobSasPermissions
 from azure.search.documents import SearchClient
 from azure.search.documents.indexes import SearchIndexClient
@@ -31,7 +31,7 @@ class AzureStorageService:
         if self._credential is None:
             settings = get_settings()
             if settings.app_env.lower() == "dev":
-                self._credential = DefaultAzureCredential(require_envvar=True)
+                self._credential = AzureCliCredential()
             else:
                 self._credential = ManagedIdentityCredential(
                     client_id=settings.azure_client_id or None

--- a/src/api/modules/ingestion/queue_service.py
+++ b/src/api/modules/ingestion/queue_service.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.storage.queue import QueueClient
 
 from src.api.config import get_settings
@@ -27,7 +27,13 @@ class QueueService:
 
     def _get_credential(self):
         if self._credential is None:
-            self._credential = DefaultAzureCredential()
+            settings = get_settings()
+            if settings.app_env.lower() == "dev":
+                self._credential = DefaultAzureCredential(require_envvar=True)
+            else:
+                self._credential = ManagedIdentityCredential(
+                    client_id=settings.azure_client_id or None
+                )
         return self._credential
 
     @staticmethod

--- a/src/api/modules/ingestion/queue_service.py
+++ b/src/api/modules/ingestion/queue_service.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+from azure.identity import AzureCliCredential, ManagedIdentityCredential
 from azure.storage.queue import QueueClient
 
 from src.api.config import get_settings
@@ -29,7 +29,7 @@ class QueueService:
         if self._credential is None:
             settings = get_settings()
             if settings.app_env.lower() == "dev":
-                self._credential = DefaultAzureCredential(require_envvar=True)
+                self._credential = AzureCliCredential()
             else:
                 self._credential = ManagedIdentityCredential(
                     client_id=settings.azure_client_id or None

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -14,7 +14,7 @@ agent-framework-foundry==1.8.2
 cachetools==5.5.2
 aiohttp==3.14.3
 numpy==2.4.6
-azure-identity==1.19.0
+azure-identity==1.25.3
 azure-search-documents==11.6.0b8
 azure-storage-blob==12.24.1
 azure-storage-queue==12.12.0


### PR DESCRIPTION
This pull request updates Azure authentication handling across several modules to support both system-assigned and user-assigned managed identities, configurable via a new `azure_client_id` setting. It also upgrades the `azure-identity` package for improved compatibility. The most important changes are grouped below:

**Authentication logic updates:**

* Added an `azure_client_id` field to the `Settings` class in `src/api/config.py`, allowing configuration of a user-assigned managed identity. If left empty, the system-assigned identity is used.
* Updated credential acquisition in `AzureSearchDataSource`, Azure Storage, and Queue Service modules to select `DefaultAzureCredential` in development and `ManagedIdentityCredential` (with optional `client_id`) in other environments. [[1]](diffhunk://#diff-0c662d52a41323244dbf894dc10a145d56826e02d6c0ad975a6d322025729484L23-R30) [[2]](diffhunk://#diff-130f08fb0be6bd895a7270491e0ba1c0d0fce911418e6ba3241c2d3a182a009eL32-R38) [[3]](diffhunk://#diff-943e52213165e6c52b66a2ab48bad7663125dfed0cc8dae9a3037177a9c6348eL30-R36)

**Dependency upgrades:**

* Upgraded `azure-identity` from version 1.19.0 to 1.25.3 in `src/api/requirements.txt` to support the latest authentication features.

**Imports and configuration:**

* Updated imports to include `ManagedIdentityCredential` and access the new settings where required. [[1]](diffhunk://#diff-0c662d52a41323244dbf894dc10a145d56826e02d6c0ad975a6d322025729484L7-R15) [[2]](diffhunk://#diff-130f08fb0be6bd895a7270491e0ba1c0d0fce911418e6ba3241c2d3a182a009eL11-R11) [[3]](diffhunk://#diff-943e52213165e6c52b66a2ab48bad7663125dfed0cc8dae9a3037177a9c6348eL8-R8)

These changes improve flexibility and security for Azure authentication, allowing the application to be deployed with either system-assigned or user-assigned managed identities as needed.## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

