### PR TITLE
fix: reject failed azd environment lookups

### DIFF
--- a/infra/scripts/post-provision/connect-data.ps1
+++ b/infra/scripts/post-provision/connect-data.ps1
@@ -34,9 +34,10 @@ function Get-AzdEnvValue {
     param([string]$Name)
     if (-not $azdAvailable) { return "" }
     $value = azd env get-value $Name 2>$null
-    if (-not $value) { return "" }
-    if ($value -is [string] -and $value.StartsWith("ERROR:")) { return "" }
-    return "$value".Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $value) { return "" }
+    $text = ($value | Out-String).Trim()
+    if ($text -match '^ERROR:') { return "" }
+    return $text
 }
 
 function Get-DiscoveredWebAppName {
@@ -62,6 +63,7 @@ function Import-AppSettingsToEnv {
         }
     }
 }
+
 
 function Sync-AgentSettingsToApi {
     param([string]$ProjectRoot)
@@ -366,4 +368,3 @@ elseif ($resolvedSourceType -eq "fabric") {
         }
     }
 }
-

--- a/infra/scripts/post-provision/setup-agent.ps1
+++ b/infra/scripts/post-provision/setup-agent.ps1
@@ -25,9 +25,10 @@ function Get-AzdEnvValue {
     param([string]$Name)
     if (-not $azdAvailable) { return "" }
     $value = azd env get-value $Name 2>$null
-    if (-not $value) { return "" }
-    if ($value -is [string] -and $value.StartsWith("ERROR:")) { return "" }
-    return "$value".Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $value) { return "" }
+    $text = ($value | Out-String).Trim()
+    if ($text -match '^ERROR:') { return "" }
+    return $text
 }
 
 function Get-DiscoveredWebAppName {


### PR DESCRIPTION
## Purpose
* Prevent failed `azd env get-value` calls from writing CLI error text into App Service settings. Invalid `USE_SQL` values caused Pydantic validation to fail during API startup, leaving the backend unavailable with HTTP 503 responses.
* Check the `azd` exit code and normalize output before accepting optional agent settings in both post-provision data paths.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* Missing optional agent keys return an empty value instead of `ERROR: key not found...`.
* Agent setup and external data connection flows only sync valid settings to the API App Service.
* The API starts successfully when optional agent keys are initially absent.

## Other Information

The failure was reproduced in an Azure deployment and recovery was validated with a healthy API plus successful SQL, Search, and Cosmos checks.