### PR TITLE
docs: Add prerequisite note for Azure AI Search network access

### DIFF
--- a/docs/ConnectDataSource.md
+++ b/docs/ConnectDataSource.md
@@ -12,6 +12,8 @@ No data is copied — the app queries your source directly at runtime using Micr
 
 You need two values: the **Search endpoint** and (optionally) the **Index name**.
 
+**Prerequisite:** The BYOD Azure AI Search service must have public network access enabled; private endpoint-only services are not supported.
+
 ### 1. Go to Azure Portal
 Go to https://portal.azure.com
 


### PR DESCRIPTION
## Purpose

This pull request adds an important prerequisite note to the data source connection documentation, clarifying network requirements for using Azure AI Search.

Documentation update:

* Added a prerequisite stating that the BYOD Azure AI Search service must have public network access enabled, as private endpoint-only services are not supported.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

